### PR TITLE
Set previous dialogs to the right status

### DIFF
--- a/src/dialog-manager.js
+++ b/src/dialog-manager.js
@@ -216,7 +216,7 @@ class DialogManager {
       dialogs.stack = dialogs.stack.slice(0, -1);
       dialogs.previous.push({
         name: dialog.name,
-        status: dialog.status,
+        status,
         characteristics: dialogInstance.characteristics,
         date: Date.now(),
       });


### PR DESCRIPTION
Previous dialogs always had the status `ready`