### PR TITLE
KevinDepuydt/dialogs-in-last-conversation

### DIFF
--- a/src/brains/brain.js
+++ b/src/brains/brain.js
@@ -62,7 +62,6 @@ class Brain {
       botId: this.botId,
       userId,
       conversations: [this.getConversationInitValue()],
-      dialogs: { stack: [], previous: [] },
       createdAt: Date.now(),
     };
   }
@@ -73,6 +72,7 @@ class Brain {
    */
   getConversationInitValue() {
     return {
+      dialogs: { stack: [], previous: [] },
       createdAt: Date.now(),
     };
   }

--- a/src/dialog-manager.js
+++ b/src/dialog-manager.js
@@ -95,7 +95,7 @@ class DialogManager extends Resolver {
    */
   async getDialogs(userId) {
     logger.debug('getDialogs', userId);
-    return this.brain.userGet(userId, 'dialogs');
+    return this.brain.conversationGet(userId, 'dialogs');
   }
 
   /**
@@ -106,7 +106,7 @@ class DialogManager extends Resolver {
    */
   async setDialogs(userId, dialogs) {
     logger.debug('setDialogs', userId, dialogs);
-    return this.brain.userSet(userId, 'dialogs', dialogs);
+    await this.brain.conversationSet(userId, 'dialogs', dialogs);
   }
 
   /**

--- a/tests/brains/brains.test.js
+++ b/tests/brains/brains.test.js
@@ -63,7 +63,6 @@ const brainTest = (brainLabel) => {
     expect(user.userId).toBe(USER_ID);
     expect(user.botId).toBe(BOT_ID);
     expect(user.conversations).toHaveLength(1);
-    expect(user.dialogs.stack).toHaveLength(0);
   });
 
   test('sets user key', async () => {
@@ -91,6 +90,7 @@ const brainTest = (brainLabel) => {
     await brain.addUser(USER_ID);
     const conversation = await brain.getLastConversation(USER_ID);
     expect(conversation).not.toBe(null);
+    expect(conversation.dialogs.stack).toHaveLength(0);
   });
 
   test('set user last conversation key', async () => {

--- a/tests/dialog-manager/dialog-manager.test.js
+++ b/tests/dialog-manager/dialog-manager.test.js
@@ -49,28 +49,28 @@ describe('DialogManager', () => {
 
   test('should keep on the stack a dialog which is waiting', async () => {
     await dm.executeIntents(null, TEST_USER, [{ name: 'waiting', value: 1.0 }], []);
-    const user = await dm.brain.getUser(TEST_USER);
-    expect(user.dialogs.stack.length).toBe(1);
+    const dialogs = await dm.brain.conversationGet(TEST_USER, 'dialogs');
+    expect(dialogs.stack.length).toBe(1);
   });
 
   test('should not stack the same dialog twice', async () => {
     await dm.executeIntents(null, TEST_USER, [{ name: 'waiting', value: 1.0 }], []);
     await dm.executeIntents(null, TEST_USER, [{ name: 'waiting', value: 1.0 }], []);
-    const user = await dm.brain.getUser(TEST_USER);
-    expect(user.dialogs.stack.length).toBe(1);
+    const dialogs = await dm.brain.conversationGet(TEST_USER, 'dialogs');
+    expect(dialogs.stack.length).toBe(1);
   });
 
   test('should empty the stack (1)', async () => {
     const adapter = new TestAdapter({ id: TEST_BOT }, {});
     await dm.executeIntents(adapter, TEST_USER, [{ name: 'default', value: 1.0 }], []);
-    const user = await dm.brain.getUser(TEST_USER);
-    expect(user.dialogs.stack.length).toBe(0);
+    const dialogs = await dm.brain.conversationGet(TEST_USER, 'dialogs');
+    expect(dialogs.stack.length).toBe(0);
   });
 
   test('should empty the stack (2)', async () => {
     const adapter = new TestAdapter({ id: TEST_BOT }, {});
     await dm.executeDialogs(adapter, TEST_USER, [{ name: 'default' }]);
-    const user = await dm.brain.getUser(TEST_USER);
-    expect(user.dialogs.stack.length).toBe(0);
+    const dialogs = await dm.brain.conversationGet(TEST_USER, 'dialogs');
+    expect(dialogs.stack.length).toBe(0);
   });
 });


### PR DESCRIPTION
- dialogs data are now stored in user last conversation
- added `brain.setDialogs` and `brain.getDialogs` helpers method to `Brain`
- fixed tests