### PR TITLE
Remove bot id + implement get/set methods in brain

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -46,7 +46,6 @@ class Bot {
     this.config = getConfiguration(config);
     logger.debug('constructor', this.config);
     checkCredentials(this.config);
-    this.id = process.env.BOTFUEL_APP_TOKEN;
     this.brain = this.getBrain(this.config.brain);
     this.nlu = new Nlu(this.config);
     this.dm = new DialogManager(this.brain, this.config);
@@ -72,10 +71,10 @@ class Bot {
   getBrain(brain) {
     switch (brain) {
       case 'mongo':
-        return new MongoBrain(this.id);
+        return new MongoBrain();
       case 'memory':
       default:
-        return new MemoryBrain(this.id);
+        return new MemoryBrain();
     }
   }
 

--- a/src/brains/brain.js
+++ b/src/brains/brain.js
@@ -217,6 +217,29 @@ class Brain {
   async setDialogs(userId, dialogs) {
     await this.conversationSet(userId, '_dialogs', dialogs);
   }
+
+  /**
+   * Gets a value for a key within the global scope.
+   * @async
+   * @abstract
+   * @param {String} key - the key
+   * @returns {Promise.<*>} the value
+   */
+  async getValue() {
+    throw new MissingImplementationError();
+  }
+
+  /**
+   * Sets a value for a key within the global scope.
+   * @async
+   * @abstract
+   * @param {String} key - the key
+   * @param {*} value - the value
+   * @returns {Promise.<*>} the new value
+   */
+  async setValue() {
+    throw new MissingImplementationError();
+  }
 }
 
 module.exports = Brain;

--- a/src/brains/brain.js
+++ b/src/brains/brain.js
@@ -24,10 +24,8 @@ const MissingImplementationError = require('../errors/missing-implementation-err
 class Brain {
   /**
    * @constructor
-   * @param {String} botId - the bot id
    */
-  constructor(botId) {
-    this.botId = botId;
+  constructor() {
     // TODO: get from config or default value below
     this.dayInMs = 86400000; // One day in milliseconds
   }
@@ -59,7 +57,6 @@ class Brain {
    */
   getUserInitValue(userId) {
     return {
-      botId: this.botId,
       userId,
       conversations: [this.getConversationInitValue()],
       createdAt: Date.now(),

--- a/src/brains/memory-brain.js
+++ b/src/brains/memory-brain.js
@@ -24,9 +24,9 @@ const Brain = require('./brain');
  */
 class MemoryBrain extends Brain {
   /** @inheritdoc */
-  constructor(botId) {
-    logger.debug('constructor', botId);
-    super(botId);
+  constructor() {
+    logger.debug('constructor');
+    super();
     this.users = {};
   }
 

--- a/src/brains/memory-brain.js
+++ b/src/brains/memory-brain.js
@@ -28,12 +28,14 @@ class MemoryBrain extends Brain {
     logger.debug('constructor');
     super();
     this.users = {};
+    this.bot = {};
   }
 
   /** @inheritdoc */
   async clean() {
     logger.debug('clean');
     this.users = {};
+    this.bot = {};
   }
 
   /** @inheritdoc */
@@ -92,6 +94,17 @@ class MemoryBrain extends Brain {
     logger.debug('conversationSet', { conversation });
     conversation[key] = value;
     return conversation;
+  }
+
+  /** @inheritdoc */
+  async getValue(key) {
+    return this.bot[key];
+  }
+
+  /** @inheritdoc */
+  async setValue(key, value) {
+    this.bot[key] = value;
+    return value;
   }
 }
 

--- a/src/messages/message.js
+++ b/src/messages/message.js
@@ -37,16 +37,14 @@ class Message extends ValidObject {
 
   /**
    * Converts a message to json and adds to it the bot and user ids.
-   * @param {String} botId - the bot id
    * @param {String} userId - the user id
    * @returns {Object} the json message
    */
-  toJson(botId, userId) {
+  toJson(userId) {
     if (this.options === undefined || this.options === null) {
       return {
         type: this.type,
         sender: this.sender,
-        bot: botId,
         user: userId,
         payload: {
           value: this.valueAsJson(),
@@ -56,7 +54,6 @@ class Message extends ValidObject {
     return {
       type: this.type,
       sender: this.sender,
-      bot: botId,
       user: userId,
       payload: {
         value: this.valueAsJson(),

--- a/src/views/view.js
+++ b/src/views/view.js
@@ -23,14 +23,13 @@ const MissingImplementationError = require('../errors/missing-implementation-err
 class View {
   /**
    * Renders a view as an array of json objects.
-   * @param {String} botId - the bot id
    * @param {String} userId - the user id
    * @param {Object} [data] - data used at display time
    * @returns {Object[]} the messages as an array json objects
    */
-  renderAsJson(botId, userId, data) {
-    logger.debug('renderAsJson', botId, userId, data);
-    return this.render(data).map(msg => msg.toJson(botId, userId));
+  renderAsJson(userId, data) {
+    logger.debug('renderAsJson', userId, data);
+    return this.render(data).map(msg => msg.toJson(userId));
   }
 
   /**

--- a/tests/brains/brains.test.js
+++ b/tests/brains/brains.test.js
@@ -22,7 +22,6 @@ const MEMORY_BRAIN_LABEL = 'memory';
 const MONGO_BRAIN_LABEL = 'mongo';
 
 // bot + user ids
-const BOT_ID = 'BOT_TEST';
 const USER_ID = 'USER_TEST';
 
 const brainTest = (brainLabel) => {
@@ -31,12 +30,12 @@ const brainTest = (brainLabel) => {
   beforeEach(async () => {
     switch (brainLabel) {
       case MONGO_BRAIN_LABEL:
-        brain = new MongoBrain(BOT_ID);
+        brain = new MongoBrain();
         await brain.init();
         break;
       case MEMORY_BRAIN_LABEL:
       default:
-        brain = new MemoryBrain(BOT_ID);
+        brain = new MemoryBrain();
     }
   });
 
@@ -154,6 +153,12 @@ const brainTest = (brainLabel) => {
     expect(dialogs.stack).toHaveLength(1);
     expect(dialogs.stack[0].name).toBe('greetings');
     expect(dialogs.previous).toHaveLength(0);
+  });
+
+  test('should set and get value', async () => {
+    await brain.setValue('test', 'hello');
+    const value = await brain.getValue('test');
+    expect(value).toEqual('hello');
   });
 };
 

--- a/tests/brains/brains.test.js
+++ b/tests/brains/brains.test.js
@@ -59,9 +59,8 @@ const brainTest = (brainLabel) => {
   test('gets a user', async () => {
     await brain.addUser(USER_ID);
     const user = await brain.getUser(USER_ID);
-    expect(Object.keys(user)).toContain('botId', 'userId', 'conversations', 'dialogs', 'createdAt');
+    expect(Object.keys(user)).toContain('userId', 'conversations', 'dialogs', 'createdAt');
     expect(user.userId).toBe(USER_ID);
-    expect(user.botId).toBe(BOT_ID);
     expect(user.conversations).toHaveLength(1);
   });
 

--- a/tests/messages/bot-text-message.test.js
+++ b/tests/messages/bot-text-message.test.js
@@ -29,10 +29,9 @@ describe('BotTextMessage', () => {
 
   test('should generate the proper json', async () => {
     const message = new BotTextMessage('foo');
-    expect(message.toJson('BOT', 'USER')).toEqual({
+    expect(message.toJson('USER')).toEqual({
       type: 'text',
       sender: 'bot',
-      bot: 'BOT',
       user: 'USER',
       payload: {
         value: 'foo',

--- a/tests/messages/cards-message.test.js
+++ b/tests/messages/cards-message.test.js
@@ -41,10 +41,9 @@ describe('CardsMessage', () => {
         new Postback('Buy', 'products', [{ dim: 'product', value: '2' }]),
       ]),
     ]);
-    expect(message.toJson('BOT', 'USER')).toEqual({
+    expect(message.toJson('USER')).toEqual({
       type: 'cards',
       sender: 'bot',
-      bot: 'BOT',
       user: 'USER',
       payload: {
         value: [

--- a/tests/messages/user-text-message.test.js
+++ b/tests/messages/user-text-message.test.js
@@ -19,10 +19,9 @@ const UserTextMessage = require('../../src/messages/user-text-message');
 describe('UserTextMessage', () => {
   test('should generate the proper json', async () => {
     const message = new UserTextMessage('foo');
-    expect(message.toJson('BOT', 'USER')).toEqual({
+    expect(message.toJson('USER')).toEqual({
       type: 'text',
       sender: 'user',
-      bot: 'BOT',
       user: 'USER',
       payload: {
         value: 'foo',


### PR DESCRIPTION
Some choices I made (tell me if you agree or not):

- Since `botId` is not needed anywhere but for botfuel webchat now, I completely removed it from the code
- You need to provide either `MONGODB_URI` or `BOTFUEL_APP_TOKEN` to use the mongo brain