### PR TITLE
Add changelog command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+<a name="1.5.1"></a>
+## [1.5.1](https://github.com/Botfuel/bot-sdk2/compare/v1.5.0...v1.5.1) (2018-01-22)
+
+
+
+
+**Note:** Version bump only for package root

--- a/lerna.json
+++ b/lerna.json
@@ -1,11 +1,13 @@
 {
   "lerna": "2.7.1",
-  "packages": ["packages/*"],
+  "packages": [
+    "packages/*"
+  ],
   "changelog": {
     "repo": "botfuel-dialog/botfuel-dialog",
     "cacheDir": ".changelog"
   },
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.5.0"
+  "version": "1.5.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,10 @@
 {
   "lerna": "2.7.1",
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
+  "changelog": {
+    "repo": "botfuel-dialog/botfuel-dialog",
+    "cacheDir": ".changelog"
+  },
   "npmClient": "yarn",
   "useWorkspaces": true,
   "version": "1.5.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "style": "lerna run style",
     "pretest": "yarn run bootstrap",
     "release":
-      "lerna run test && lerna run compile --scope botfuel-dialog && lerna publish",
+      "lerna run test && lerna run compile --scope botfuel-dialog && lerna publish --conventional-commits --changelog-preset=angular",
     "unit-test": "lerna run test --scope botfuel-dialog",
     "test": "lerna run test"
   },

--- a/packages/botfuel-dialog/CHANGELOG.md
+++ b/packages/botfuel-dialog/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+<a name="1.5.1"></a>
+## [1.5.1](https://github.com/Botfuel/botfuel-dialog/compare/v1.5.0...v1.5.1) (2018-01-22)
+
+
+
+
+**Note:** Version bump only for package botfuel-dialog

--- a/packages/botfuel-dialog/package.json
+++ b/packages/botfuel-dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botfuel-dialog",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": "sysadmin@botfuel.io",
   "main": "index.js",
   "description": "Botfuel Dialog",
@@ -9,7 +9,9 @@
     "url": "https://github.com/Botfuel/botfuel-dialog"
   },
   "license": "Apache-2.0",
-  "files": ["build"],
+  "files": [
+    "build"
+  ],
   "bin": {
     "botfuel-run": "./build/run.js",
     "botfuel-train": "./build/train.js",
@@ -17,13 +19,20 @@
   },
   "scripts": {
     "compile": "rm -rf build; babel src --out-dir build; cp -r src/corpora/*.txt build/corpora/",
+<<<<<<< HEAD
     "test": "BOTFUEL_APP_TOKEN=TEST_BOT jest --testPathPattern='botfuel-dialog/tests' --forceExit",
+=======
+    "test": "BOTFUEL_APP_TOKEN=TEST_BOT MONGODB_URI=mongodb://localhost/sdk-brain-test jest --testPathPattern='botfuel-dialog/tests' --forceExit",
+>>>>>>> feat: Add changelog
     "style": "eslint src; eslint tests",
     "docs": "node_modules/.bin/jsdoc --configure .jsdoc.json --verbose",
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "*.js": ["prettier-eslint --write \"{src,tests}/**/*.js\"", "git add"]
+    "*.js": [
+      "prettier-eslint --write \"{src,tests}/**/*.js\"",
+      "git add"
+    ]
   },
   "dependencies": {
     "babel-polyfill": "^6.26.0",

--- a/packages/test-complexdialogs/.gitignore
+++ b/packages/test-complexdialogs/.gitignore
@@ -69,3 +69,5 @@ typings/
 
 # editors files
 .idea
+
+CHANGELOG.md

--- a/packages/test-complexdialogs/package.json
+++ b/packages/test-complexdialogs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sample-botfuel-dialog-complexdialogs",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "author": "sysadmin@botfuel.io",
   "description": "Sample bot using botfuel-dialog and illustrating complex dialogs",

--- a/packages/test-complexentities/.gitignore
+++ b/packages/test-complexentities/.gitignore
@@ -69,3 +69,5 @@ typings/
 
 # editors files
 .idea
+
+CHANGELOG.md

--- a/packages/test-complexentities/package.json
+++ b/packages/test-complexentities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sample-botfuel-dialog-complexentities",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "author": "sysadmin@botfuel.io",
   "description": "Sample bot using botfuel-dialog and illustrating complex dialogs entities",

--- a/packages/test-ecommerce/.gitignore
+++ b/packages/test-ecommerce/.gitignore
@@ -69,3 +69,5 @@ typings/
 
 # editors files
 .idea
+
+CHANGELOG.md

--- a/packages/test-ecommerce/package.json
+++ b/packages/test-ecommerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-ecommerce",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "author": "sysadmin@botfuel.io",
   "description": "Bot testing and illustrating an ecommerce botfuel-dialog bot",

--- a/packages/test-qna/.gitignore
+++ b/packages/test-qna/.gitignore
@@ -69,3 +69,5 @@ typings/
 
 # editors files
 .idea
+
+CHANGELOG.md

--- a/packages/test-qna/package.json
+++ b/packages/test-qna/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-qna",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "author": "sysadmin@botfuel.io",
   "description": "Bot testing botfuel-dialog and qna",
@@ -9,8 +9,7 @@
     "start": "botfuel-run",
     "train": "botfuel-train",
     "clean": "botfuel-clean",
-    "test":
-      "BOTFUEL_APP_TOKEN=TEST_BOT mocha --timeout 30000 --require babel-polyfill --require babel-register tests/*.js",
+    "test": "BOTFUEL_APP_TOKEN=TEST_BOT mocha --timeout 30000 --require babel-polyfill --require babel-register tests/*.js",
     "style": "eslint src; eslint tests"
   },
   "dependencies": {


### PR DESCRIPTION
Process:

- Write commit messages following https://conventionalcommits.org
- Make a PR
- Merge PR
- Release (using `yarn release`) when needed, this will automatically add new content to CHANGELOG.md (we can still edit CHANGELOG.md by hand, changes won't be overriden)

I chose the angular preset (default lerna preset):

If the prefix is feat, fix or perf, it will appear in the changelog. However if there is any BREAKING CHANGE, the commit will always appear in the changelog.

- `fix: Fix hello function` => Patch bump
- `feat: Add new functionality` => Minor bump
- `perf: Improve performance of hello function` => not sure if patch bump or no bump
- If there is `BREAKING CHANGE` in the commit message => Major bump

Other prefixes that don't update changelog: automatically:

- docs
- chore 
- style
- refactor
- test


We can also add a scope to each message:

```
fix(dialog-manager): Fix ...
```