### PR TITLE
fix: send question for entity with highest priority first in prompt-view

### DIFF
--- a/packages/botfuel-dialog/src/views/prompt-view.js
+++ b/packages/botfuel-dialog/src/views/prompt-view.js
@@ -57,7 +57,10 @@ class PromptView extends View {
 
       // highest priority entity must be asked first
       const { entity } = _.maxBy(
-        Object.keys(missingEntities).map(entity => ({ entity, priority: missingEntities[entity].priority | 0 })),
+        Object.keys(missingEntities).map(key => ({
+          entity: key,
+          priority: missingEntities[key].priority || 0,
+        })),
         'priority',
       );
       messages.push(new BotTextMessage(`Which ${entity}?`));

--- a/packages/botfuel-dialog/src/views/prompt-view.js
+++ b/packages/botfuel-dialog/src/views/prompt-view.js
@@ -15,6 +15,7 @@
  */
 
 const logger = require('logtown')('PromptView');
+const _ = require('lodash');
 const BotTextMessage = require('../messages/bot-text-message');
 const View = require('./view');
 
@@ -53,7 +54,13 @@ class PromptView extends View {
       messages.push(
         new BotTextMessage(`Entities needed: ${Object.keys(missingEntities).join(', ')}`),
       );
-      messages.push(new BotTextMessage(`Which ${Object.keys(missingEntities)[0]}?`));
+
+      // highest priority entity must be asked first
+      const { entity } = _.maxBy(
+        Object.keys(missingEntities).map(entity => ({ entity, priority: missingEntities[entity].priority | 0 })),
+        'priority',
+      );
+      messages.push(new BotTextMessage(`Which ${entity}?`));
     }
     return messages;
   }

--- a/packages/botfuel-dialog/tests/views/prompt-view.test.js
+++ b/packages/botfuel-dialog/tests/views/prompt-view.test.js
@@ -57,5 +57,24 @@ describe('PromptView', () => {
         ]);
       });
     });
+
+    describe('when missing entities have different priority', () => {
+      test('should ask highest priority entity first', () => {
+        expect(
+          view.render(
+            {
+              user: null,
+            },
+            {
+              matchedEntities: {},
+              missingEntities: { name1: { priority: 0 }, name2: { priority: 1 } },
+            },
+          ),
+        ).toEqual([
+          new BotTextMessage('Entities needed: name1, name2'),
+          new BotTextMessage('Which name2?'),
+        ]);
+      });
+    });
   });
 });


### PR DESCRIPTION
prompt view must send question for highest priority entity first since the entity are matched based on (dimension + priority order). This only impact the case where some entities have same dimension but different priority (before we can ask for one entity but match other entity)