### PR TITLE
fix: Fix lerna run style

### DIFF
--- a/packages/botfuel-dialog/package.json
+++ b/packages/botfuel-dialog/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "compile": "rm -rf build; ../../node_modules/.bin/babel src --out-dir build; cp -r src/corpora/*.txt build/corpora/",
     "test": "BOTFUEL_APP_TOKEN=TEST_BOT jest",
-    "style": "eslint src; eslint tests",
+    "style": "eslint src && eslint tests",
     "docs": "node_modules/.bin/jsdoc --configure .jsdoc.json --verbose",
     "precommit": "lint-staged"
   },

--- a/packages/test-complexdialogs/package.json
+++ b/packages/test-complexdialogs/package.json
@@ -10,7 +10,7 @@
     "train": "botfuel-train",
     "clean": "botfuel-clean",
     "test": "jest",
-    "style": "eslint src; eslint tests"
+    "style": "eslint src && eslint tests"
   },
   "dependencies": {
     "botfuel-dialog": "latest"

--- a/packages/test-complexentities/package.json
+++ b/packages/test-complexentities/package.json
@@ -10,7 +10,7 @@
     "train": "botfuel-train",
     "clean": "botfuel-clean",
     "test": "jest",
-    "style": "eslint src; eslint tests"
+    "style": "eslint src && eslint tests"
   },
   "dependencies": {
     "botfuel-dialog": "latest"

--- a/packages/test-ecommerce/package.json
+++ b/packages/test-ecommerce/package.json
@@ -10,7 +10,7 @@
     "train": "botfuel-train",
     "clean": "botfuel-clean",
     "test": "jest",
-    "style": "eslint src; eslint tests"
+    "style": "eslint src && eslint tests"
   },
   "dependencies": {
     "botfuel-dialog": "latest"

--- a/packages/test-middlewares/package.json
+++ b/packages/test-middlewares/package.json
@@ -10,7 +10,7 @@
     "train": "botfuel-train",
     "clean": "botfuel-clean",
     "test": "jest",
-    "style": "eslint src; eslint tests"
+    "style": "eslint src && eslint tests"
   },
   "dependencies": {
     "botfuel-dialog": "latest"

--- a/packages/test-modules/package.json
+++ b/packages/test-modules/package.json
@@ -10,7 +10,7 @@
     "train": "botfuel-train",
     "clean": "botfuel-clean",
     "test": "jest",
-    "style": "eslint src; eslint tests"
+    "style": "eslint src && eslint tests"
   },
   "dependencies": {
     "botfuel-dialog": "latest",

--- a/packages/test-qna/package.json
+++ b/packages/test-qna/package.json
@@ -10,7 +10,7 @@
     "train": "botfuel-train",
     "clean": "botfuel-clean",
     "test": "jest",
-    "style": "eslint src; eslint tests"
+    "style": "eslint src && eslint tests"
   },
   "dependencies": {
     "botfuel-dialog": "latest"

--- a/packages/test-resolvers/package.json
+++ b/packages/test-resolvers/package.json
@@ -10,7 +10,7 @@
     "train": "botfuel-train",
     "clean": "botfuel-clean",
     "test": "jest",
-    "style": "eslint src; eslint tests"
+    "style": "eslint src && eslint tests"
   },
   "dependencies": {
     "botfuel-dialog": "latest"


### PR DESCRIPTION
When `lerna run my_command`where `my_command: "command1; command2"`, only `command2` gets checked for non-zero status code.

For example: `"style": "eslint src; eslint tests",` lints only for tests...