### PR TITLE
Canh/fix windows

### DIFF
--- a/packages/botfuel-dialog/src/classifier.js
+++ b/packages/botfuel-dialog/src/classifier.js
@@ -109,7 +109,8 @@ class Classifier {
           Object.assign(map, {
             [intent.intentName]: fs
               .readFileSync(`${intentsDirPath}/${intent.fileName}`, 'utf8')
-              .toString(),
+              .toString()
+              .replace(/\r/g, ''),
           }),
         {},
       );
@@ -194,7 +195,10 @@ class Classifier {
         const intent = fileName.substring(0, fileName.length - INTENT_SUFFIX.length);
         logger.debug('train: intent', intent);
 
-        const content = fs.readFileSync(`${this.intentDirname}/${fileName}`, 'utf8').toString();
+        const content = fs
+          .readFileSync(`${this.intentDirname}/${fileName}`, 'utf8')
+          .toString()
+          .replace(/\r/g, '');
 
         return content.split('\n').map((line) => {
           logger.debug('train: line', line);

--- a/packages/botfuel-dialog/src/corpora/file-corpus.js
+++ b/packages/botfuel-dialog/src/corpora/file-corpus.js
@@ -33,6 +33,7 @@ class FileCorpus extends Corpus {
       fs
         .readFileSync(path, 'utf8') // TODO: async?
         .toString()
+        .replace(/\r/g, '') // windows introduce \r
         .split('\n')
         .filter(row => row.length > 0)
         .map(row => row.split(separator)),

--- a/packages/botfuel-dialog/tests/corpora/file-corpus.test.js
+++ b/packages/botfuel-dialog/tests/corpora/file-corpus.test.js
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
+const path = require('path');
 const FileCorpus = require('../../src/corpora/file-corpus');
 
 describe('FileCorpus', () => {
   test('should retrieve the correct values', () => {
-    const corpus = new FileCorpus(`${__dirname}/test-corpus.en.txt`);
+    const corpus = new FileCorpus(path.resolve(__dirname, './test-corpus.en.txt'));
     expect(corpus.getValue('that')).not.toBe(null);
     expect(corpus.getValue('not')).toBe(null);
   });
 
   test('should not retrieve empty rows', () => {
-    const corpus = new FileCorpus(`${__dirname}/test-corpus.en.txt`);
+    const corpus = new FileCorpus(path.resolve(__dirname, './test-corpus.en.txt'));
     expect(corpus.matrix.length).toBe(5);
   });
 });

--- a/packages/botfuel-dialog/tests/dialog-manager/dialog-manager.test.js
+++ b/packages/botfuel-dialog/tests/dialog-manager/dialog-manager.test.js
@@ -16,6 +16,7 @@
 
 // require('../../src/logger-manager').configure({ logger: 'botfuel'});
 
+const path = require('path');
 const Bot = require('../../src/bot');
 const Dialog = require('../../src/dialogs/dialog');
 const ClassificationResult = require('../../src/nlus/classification-result');
@@ -44,7 +45,7 @@ describe('DialogManager', () => {
   });
 
   test('when given a name, it should return the correct path', () => {
-    expect(dm.getPath('test')).toEqual(`${__dirname}/src/dialogs/test-dialog.js`);
+    expect(dm.getPath('test')).toEqual(path.resolve(__dirname, './src/dialogs/test-dialog.js'));
   });
 
   test('when given an unknown name, it should return null', () => {


### PR DESCRIPTION
- remove \r when reading intents, corpus files in windows
- use path for file path resolution for cross-platform