### PR TITLE
fix: add manage error comma in Corpus

### DIFF
--- a/packages/botfuel-dialog/src/corpora/corpus.js
+++ b/packages/botfuel-dialog/src/corpora/corpus.js
@@ -16,6 +16,7 @@
 
 /* eslint-disable valid-jsdoc */
 const Diacritics = require('diacritics');
+const ExtractorError = require('../errors/extractor-error');
 const logger = require('logtown')('Corpus');
 
 /**
@@ -44,9 +45,18 @@ class Corpus {
    * @constructor
    * @param {String[][]} matrix - the corpus matrix,
    * a row of the matrix corresponds to words with common meaning
+   * @param {String} path - the file path
    */
-  constructor(matrix) {
+  constructor(matrix, name) {
     logger.debug('constructor', matrix);
+    for (const row of matrix) {
+      for (const word of row) {
+        if (word.length === 0) {
+          throw new ExtractorError(`The corpus ${name} is not formatted properly.
+           Make sure it doesn’t contain trailing commas.`);
+        }
+      }
+    }
     this.matrix = matrix;
   }
 

--- a/packages/botfuel-dialog/src/corpora/file-corpus.js
+++ b/packages/botfuel-dialog/src/corpora/file-corpus.js
@@ -36,7 +36,7 @@ class FileCorpus extends Corpus {
         .replace(/\r/g, '') // windows introduce \r
         .split('\n')
         .filter(row => row.length > 0)
-        .map(row => row.split(separator)),
+        .map(row => row.split(separator)), path,
     );
   }
 }

--- a/packages/botfuel-dialog/tests/corpora/corpus.test.js
+++ b/packages/botfuel-dialog/tests/corpora/corpus.test.js
@@ -15,6 +15,7 @@
  */
 
 const Corpus = require('../../src/corpora/corpus');
+const ExtractorError = require('../../src/errors/extractor-error');
 
 describe('Corpus', () => {
   test('should properly normalize', () => {
@@ -45,5 +46,16 @@ describe('Corpus', () => {
     );
     expect(corpus.getValue('Montbeliard')).toBe('Montbéliard');
     expect(corpus.getValue('Montbeliard', { keepAccents: true })).not.toBe('Montbéliard');
+  });
+
+  test('should throw an ExtractorError', () => {
+    expect(() => new Corpus(
+      [
+        ['should', '', '', ''],
+        ['Olympique Lyonnais', "L'Olympique Lyonnais", 'OL'],
+        ['Football Club de Nantes', 'FCN'],
+        ['Montbéliard'],
+      ],
+    )).toThrow(ExtractorError);
   });
 });

--- a/packages/botfuel-dialog/tests/corpora/file-corpus.test.js
+++ b/packages/botfuel-dialog/tests/corpora/file-corpus.test.js
@@ -16,6 +16,7 @@
 
 const path = require('path');
 const FileCorpus = require('../../src/corpora/file-corpus');
+const ExtractorError = require('../../src/errors/extractor-error');
 
 describe('FileCorpus', () => {
   test('should retrieve the correct values', () => {
@@ -27,5 +28,20 @@ describe('FileCorpus', () => {
   test('should not retrieve empty rows', () => {
     const corpus = new FileCorpus(path.resolve(__dirname, './test-corpus.en.txt'));
     expect(corpus.matrix.length).toBe(5);
+  });
+
+  test('should not throw when the corpus file name contains a trailing comma', () => {
+    const corpus = new FileCorpus(path.resolve(__dirname, './test-corpus,comma.txt'));
+    expect(corpus.matrix.length).toBe(5);
+  });
+
+  test('should throw an ExtractorError when the corpus file contains trailing comma', () => {
+    expect(() => new FileCorpus(path.resolve(__dirname, './test-corpus-much-comma.txt')))
+      .toThrow(ExtractorError);
+  });
+
+  test('should throw Extractor Error when corpus file contains a line with only comma', () => {
+    expect(() => new FileCorpus(path.resolve(__dirname, './test-corpus-comma.txt')))
+      .toThrow(ExtractorError);
   });
 });

--- a/packages/botfuel-dialog/tests/corpora/test-corpus,comma.txt
+++ b/packages/botfuel-dialog/tests/corpora/test-corpus,comma.txt
@@ -1,0 +1,7 @@
+should
+contain
+this, that
+
+and
+
+that

--- a/packages/botfuel-dialog/tests/corpora/test-corpus-comma.txt
+++ b/packages/botfuel-dialog/tests/corpora/test-corpus-comma.txt
@@ -1,0 +1,7 @@
+should
+contain
+this, that
+,
+and,
+
+that

--- a/packages/botfuel-dialog/tests/corpora/test-corpus-much-comma.txt
+++ b/packages/botfuel-dialog/tests/corpora/test-corpus-much-comma.txt
@@ -1,0 +1,6 @@
+should,,,,,
+contain,,
+this, that,,,,,,
+and,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,would
+that,,,,,,,,,


### PR DESCRIPTION
fix corpus comma error. When we have a error format, return ExtractorError

task Asana : https://app.asana.com/0/481142309329793/670660760628697