### PR TITLE
fix: fix messenger bot when we have disambiguation view

### DIFF
--- a/packages/botfuel-dialog/src/views/classification-disambiguation-view.js
+++ b/packages/botfuel-dialog/src/views/classification-disambiguation-view.js
@@ -38,7 +38,11 @@ class ClassificationDisambiguationView extends View {
       return new Postback(resolvePrompt, cr.name, messageEntities);
     });
 
-    return [new BotTextMessage('What do you mean?'), new ActionsMessage(postbacks)];
+    const option = {
+      text: 'disambiguation',
+    };
+
+    return [new BotTextMessage('What do you mean?'), new ActionsMessage(postbacks, option)];
   }
 }
 


### PR DESCRIPTION
When we had disambiguation view, the bot crash before we hadn't payload.option
Now, we have option.text

task Asana : https://app.asana.com/0/481142309329793/693136421889456