### PR TITLE
fix: fix messenger bot when we have disambiguation view

### DIFF
--- a/packages/botfuel-dialog/src/views/classification-disambiguation-view.js
+++ b/packages/botfuel-dialog/src/views/classification-disambiguation-view.js
@@ -38,7 +38,11 @@ class ClassificationDisambiguationView extends View {
       return new Postback(resolvePrompt, cr.name, messageEntities);
     });
 
-    return [new BotTextMessage('What do you mean?'), new ActionsMessage(postbacks)];
+    const option = {
+      text: 'disambiguation',
+    };
+
+    return [new BotTextMessage('What do you mean?'), new ActionsMessage(postbacks, option)];
   }
 }
 

--- a/packages/botfuel-dialog/src/views/classification-disambiguation-view.js
+++ b/packages/botfuel-dialog/src/views/classification-disambiguation-view.js
@@ -39,10 +39,10 @@ class ClassificationDisambiguationView extends View {
     });
 
     const option = {
-      text: 'disambiguation',
+      text: 'What do you mean ? ',
     };
 
-    return [new BotTextMessage('What do you mean?'), new ActionsMessage(postbacks, option)];
+    return [new ActionsMessage(postbacks, option)];
   }
 }
 

--- a/packages/botfuel-dialog/tests/views/classification-disambiguation-view.test.js
+++ b/packages/botfuel-dialog/tests/views/classification-disambiguation-view.test.js
@@ -36,7 +36,9 @@ describe('ClassificationDisambiguationView', () => {
       }),
     ];
     const view = new ClassificationDisambiguationView();
-
+    const option = {
+      text: 'disambiguation',
+    };
     test('should return correct choices for both intents and qnas', () => {
       expect(
         view.render({ user: 'TEST_USER' }, { classificationResults, messageEntities: [] }),
@@ -47,7 +49,7 @@ describe('ClassificationDisambiguationView', () => {
           new Postback('You want delivery information?', 'qnas', [
             [{ value: 'Here is your delivery information' }],
           ]),
-        ]),
+        ], option),
       ]);
     });
   });


### PR DESCRIPTION
When we had disambiguation view, the bot crash before we hadn't payload.option
Now, we have option.text