### PR TITLE
fix: fix messenger bot when we have disambiguation view

### DIFF
--- a/packages/botfuel-dialog/src/views/classification-disambiguation-view.js
+++ b/packages/botfuel-dialog/src/views/classification-disambiguation-view.js
@@ -16,7 +16,6 @@
 
 const logger = require('logtown')('IntentResolutionView');
 const ActionsMessage = require('../messages/actions-message');
-const BotTextMessage = require('../messages/bot-text-message');
 const Postback = require('../messages/postback');
 const View = require('./view');
 
@@ -38,7 +37,10 @@ class ClassificationDisambiguationView extends View {
       return new Postback(resolvePrompt, cr.name, messageEntities);
     });
 
-    return [new BotTextMessage('What do you mean?'), new ActionsMessage(postbacks)];
+    const options = {
+      text: 'What do you mean ? ',
+    };
+    return [new ActionsMessage(postbacks, options)];
   }
 }
 

--- a/packages/botfuel-dialog/tests/views/classification-disambiguation-view.test.js
+++ b/packages/botfuel-dialog/tests/views/classification-disambiguation-view.test.js
@@ -16,7 +16,6 @@
 
 const ClassificationDisambiguationView = require('../../src/views/classification-disambiguation-view');
 const ActionsMessage = require('../../src/messages/actions-message');
-const BotTextMessage = require('../../src/messages/bot-text-message');
 const Postback = require('../../src/messages/postback');
 const ClassificationResult = require('../../src/nlus/classification-result');
 
@@ -36,18 +35,19 @@ describe('ClassificationDisambiguationView', () => {
       }),
     ];
     const view = new ClassificationDisambiguationView();
-
+    const option = {
+      text: 'What do you mean ? ',
+    };
     test('should return correct choices for both intents and qnas', () => {
       expect(
         view.render({ user: 'TEST_USER' }, { classificationResults, messageEntities: [] }),
       ).toEqual([
-        new BotTextMessage('What do you mean?'),
         new ActionsMessage([
           new Postback('You want trip information?', 'trip', []),
           new Postback('You want delivery information?', 'qnas', [
             [{ value: 'Here is your delivery information' }],
           ]),
-        ]),
+        ], option),
       ]);
     });
   });


### PR DESCRIPTION
When we had disambiguation view, the bot crash before we hadn't payload.option
Now, the bot display choice in messenger when we have a disambiguation

task Asana: https://app.asana.com/0/481142309329793/693136421889456