### PR TITLE
changed name of getLastConversation for lastConversation

### DIFF
--- a/packages/botfuel-dialog/src/brains/brain.js
+++ b/packages/botfuel-dialog/src/brains/brain.js
@@ -128,11 +128,11 @@ class Brain {
   }
 
   /**
-   * Gets the last conversation of the user.
-   * If the last conversation is not valid anymore, adds a new one and returns it.
+   * Fetches the last conversation of the user. 
+   * If the last conversation found isn't valid anymore, adds a new one and returns it.
    * @returns the last conversation of the user
    */
-  async lastConversation(
+  async fetchLastConversation(
     userId: string, // eslint-disable-line no-unused-vars
   ): Promise<ConversationData> {
     throw new MissingImplementationError();
@@ -178,7 +178,7 @@ class Brain {
    */
   async conversationGet(userId: string, key: string): Promise<mixed> {
     logger.debug('conversationGet', userId, key);
-    const conversation = await this.lastConversation(userId);
+    const conversation = await this.fetchLastConversation(userId);
     return conversation[key];
   }
 

--- a/packages/botfuel-dialog/src/brains/brain.js
+++ b/packages/botfuel-dialog/src/brains/brain.js
@@ -129,9 +129,10 @@ class Brain {
 
   /**
    * Gets the last conversation of the user.
+   * If the last conversation is not valid anymore, adds a new one and returns it.
    * @returns the last conversation of the user
    */
-  async getLastConversation(
+  async lastConversation(
     userId: string, // eslint-disable-line no-unused-vars
   ): Promise<ConversationData> {
     throw new MissingImplementationError();
@@ -177,7 +178,7 @@ class Brain {
    */
   async conversationGet(userId: string, key: string): Promise<mixed> {
     logger.debug('conversationGet', userId, key);
-    const conversation = await this.getLastConversation(userId);
+    const conversation = await this.lastConversation(userId);
     return conversation[key];
   }
 

--- a/packages/botfuel-dialog/src/brains/brain.js
+++ b/packages/botfuel-dialog/src/brains/brain.js
@@ -128,7 +128,7 @@ class Brain {
   }
 
   /**
-   * Fetches the last conversation of the user. 
+   * Fetches the last conversation of the user.
    * If the last conversation found isn't valid anymore, adds a new one and returns it.
    * @returns the last conversation of the user
    */

--- a/packages/botfuel-dialog/src/brains/memory-brain.js
+++ b/packages/botfuel-dialog/src/brains/memory-brain.js
@@ -78,8 +78,8 @@ class MemoryBrain extends Brain {
   }
 
   /** @inheritdoc */
-  async getLastConversation(userId) {
-    logger.debug('getLastConversation', userId);
+  async lastConversation(userId) {
+    logger.debug('lastConversation', userId);
     const user = await this.getUser(userId);
     const conversation = last(user._conversations);
     return this.isConversationValid(conversation) ? conversation : this.addConversation(userId);
@@ -97,7 +97,7 @@ class MemoryBrain extends Brain {
   /** @inheritdoc */
   async conversationSet(userId, key, value) {
     logger.debug('conversationSet', userId, key, value);
-    const lastConversation = await this.getLastConversation(userId);
+    const lastConversation = await this.lastConversation(userId);
     lastConversation[key] = value;
     return lastConversation;
   }

--- a/packages/botfuel-dialog/src/brains/memory-brain.js
+++ b/packages/botfuel-dialog/src/brains/memory-brain.js
@@ -78,8 +78,8 @@ class MemoryBrain extends Brain {
   }
 
   /** @inheritdoc */
-  async lastConversation(userId) {
-    logger.debug('lastConversation', userId);
+  async fetchLastConversation(userId) {
+    logger.debug('fetchLastConversation', userId);
     const user = await this.getUser(userId);
     const conversation = last(user._conversations);
     return this.isConversationValid(conversation) ? conversation : this.addConversation(userId);
@@ -97,7 +97,7 @@ class MemoryBrain extends Brain {
   /** @inheritdoc */
   async conversationSet(userId, key, value) {
     logger.debug('conversationSet', userId, key, value);
-    const lastConversation = await this.lastConversation(userId);
+    const lastConversation = await this.fetchLastConversation(userId);
     lastConversation[key] = value;
     return lastConversation;
   }

--- a/packages/botfuel-dialog/src/brains/mongo-brain.js
+++ b/packages/botfuel-dialog/src/brains/mongo-brain.js
@@ -131,8 +131,8 @@ class MongoBrain extends Brain {
   }
 
   /** @inheritdoc */
-  async lastConversation(userId) {
-    logger.debug('lastConversation', userId);
+  async fetchLastConversation(userId) {
+    logger.debug('fetchLastConversation', userId);
     const user = await this.getUser(userId, { _conversations: { $slice: 1 } });
     const conversation = user._conversations[0];
     return this.isConversationValid(conversation) ? conversation : this.addConversation(userId);

--- a/packages/botfuel-dialog/src/brains/mongo-brain.js
+++ b/packages/botfuel-dialog/src/brains/mongo-brain.js
@@ -131,8 +131,8 @@ class MongoBrain extends Brain {
   }
 
   /** @inheritdoc */
-  async getLastConversation(userId) {
-    logger.debug('getLastConversation', userId);
+  async lastConversation(userId) {
+    logger.debug('lastConversation', userId);
     const user = await this.getUser(userId, { _conversations: { $slice: 1 } });
     const conversation = user._conversations[0];
     return this.isConversationValid(conversation) ? conversation : this.addConversation(userId);

--- a/packages/botfuel-dialog/tests/adapters/adapter.test.js
+++ b/packages/botfuel-dialog/tests/adapters/adapter.test.js
@@ -55,7 +55,7 @@ describe('Adapter', () => {
     await bot.init();
     const message = new UserTextMessage('message').toJson(userId);
     await bot.adapter.handleMessage(message);
-    const conversation = await bot.brain.lastConversation(userId);
+    const conversation = await bot.brain.fetchLastConversation(userId);
     expect(conversation._dialogs.previous.length).toBe(1);
   });
 

--- a/packages/botfuel-dialog/tests/adapters/adapter.test.js
+++ b/packages/botfuel-dialog/tests/adapters/adapter.test.js
@@ -55,7 +55,7 @@ describe('Adapter', () => {
     await bot.init();
     const message = new UserTextMessage('message').toJson(userId);
     await bot.adapter.handleMessage(message);
-    const conversation = await bot.brain.getLastConversation(userId);
+    const conversation = await bot.brain.lastConversation(userId);
     expect(conversation._dialogs.previous.length).toBe(1);
   });
 

--- a/packages/botfuel-dialog/tests/adapters/test-adapter.test.js
+++ b/packages/botfuel-dialog/tests/adapters/test-adapter.test.js
@@ -37,7 +37,7 @@ describe('TestAdapter', () => {
     const bot = new Bot({ adapter: { name: 'test' } });
     await bot.init();
     await bot.adapter.play(messages);
-    const conversation = await bot.brain.getLastConversation(bot.adapter.userId);
+    const conversation = await bot.brain.lastConversation(bot.adapter.userId);
     expect(conversation._dialogs.previous.length).toBe(2);
   });
 });

--- a/packages/botfuel-dialog/tests/adapters/test-adapter.test.js
+++ b/packages/botfuel-dialog/tests/adapters/test-adapter.test.js
@@ -37,7 +37,7 @@ describe('TestAdapter', () => {
     const bot = new Bot({ adapter: { name: 'test' } });
     await bot.init();
     await bot.adapter.play(messages);
-    const conversation = await bot.brain.lastConversation(bot.adapter.userId);
+    const conversation = await bot.brain.fetchLastConversation(bot.adapter.userId);
     expect(conversation._dialogs.previous.length).toBe(2);
   });
 });

--- a/packages/botfuel-dialog/tests/brains/brains.test.js
+++ b/packages/botfuel-dialog/tests/brains/brains.test.js
@@ -120,7 +120,7 @@ const brainTest = (brainLabel) => {
 
   test('get last user conversation', async () => {
     await brain.addUser(USER_ID);
-    const conversation = await brain.getLastConversation(USER_ID);
+    const conversation = await brain.lastConversation(USER_ID);
     const { _dialogs } = conversation;
     expect(conversation).not.toBe(null);
     expect(_dialogs.stack).toHaveLength(0);
@@ -129,7 +129,7 @@ const brainTest = (brainLabel) => {
   test('get last user conversation when no conversation', async () => {
     await brain.addUser(USER_ID);
     await brain.userSet(USER_ID, '_conversations', []);
-    const conversation = await brain.getLastConversation(USER_ID);
+    const conversation = await brain.lastConversation(USER_ID);
     const { _dialogs } = conversation;
     expect(conversation).not.toBe(null);
     expect(_dialogs.stack).toHaveLength(0);
@@ -317,10 +317,10 @@ describe('Brains', () => {
         }
       });
 
-      test('getLastConversation', async () => {
+      test('lastConversation', async () => {
         expect.assertions(1);
         try {
-          await new Brain(BRAIN_CONFIG).getLastConversation();
+          await new Brain(BRAIN_CONFIG).lastConversation();
         } catch (e) {
           expect(e.message).toEqual('Not implemented!');
         }

--- a/packages/botfuel-dialog/tests/brains/brains.test.js
+++ b/packages/botfuel-dialog/tests/brains/brains.test.js
@@ -120,7 +120,7 @@ const brainTest = (brainLabel) => {
 
   test('get last user conversation', async () => {
     await brain.addUser(USER_ID);
-    const conversation = await brain.lastConversation(USER_ID);
+    const conversation = await brain.fetchastConversation(USER_ID);
     const { _dialogs } = conversation;
     expect(conversation).not.toBe(null);
     expect(_dialogs.stack).toHaveLength(0);
@@ -129,7 +129,7 @@ const brainTest = (brainLabel) => {
   test('get last user conversation when no conversation', async () => {
     await brain.addUser(USER_ID);
     await brain.userSet(USER_ID, '_conversations', []);
-    const conversation = await brain.lastConversation(USER_ID);
+    const conversation = await brain.fetchastConversation(USER_ID);
     const { _dialogs } = conversation;
     expect(conversation).not.toBe(null);
     expect(_dialogs.stack).toHaveLength(0);
@@ -317,10 +317,10 @@ describe('Brains', () => {
         }
       });
 
-      test('lastConversation', async () => {
+      test('fetchastConversation', async () => {
         expect.assertions(1);
         try {
-          await new Brain(BRAIN_CONFIG).lastConversation();
+          await new Brain(BRAIN_CONFIG).fetchastConversation();
         } catch (e) {
           expect(e.message).toEqual('Not implemented!');
         }

--- a/packages/botfuel-dialog/tests/brains/brains.test.js
+++ b/packages/botfuel-dialog/tests/brains/brains.test.js
@@ -120,7 +120,7 @@ const brainTest = (brainLabel) => {
 
   test('get last user conversation', async () => {
     await brain.addUser(USER_ID);
-    const conversation = await brain.fetchastConversation(USER_ID);
+    const conversation = await brain.fetchLastConversation(USER_ID);
     const { _dialogs } = conversation;
     expect(conversation).not.toBe(null);
     expect(_dialogs.stack).toHaveLength(0);
@@ -129,7 +129,7 @@ const brainTest = (brainLabel) => {
   test('get last user conversation when no conversation', async () => {
     await brain.addUser(USER_ID);
     await brain.userSet(USER_ID, '_conversations', []);
-    const conversation = await brain.fetchastConversation(USER_ID);
+    const conversation = await brain.fetchLastConversation(USER_ID);
     const { _dialogs } = conversation;
     expect(conversation).not.toBe(null);
     expect(_dialogs.stack).toHaveLength(0);
@@ -317,10 +317,10 @@ describe('Brains', () => {
         }
       });
 
-      test('fetchastConversation', async () => {
+      test('fetchLastConversation', async () => {
         expect.assertions(1);
         try {
-          await new Brain(BRAIN_CONFIG).fetchastConversation();
+          await new Brain(BRAIN_CONFIG).fetchLastConversation();
         } catch (e) {
           expect(e.message).toEqual('Not implemented!');
         }

--- a/packages/botfuel-dialog/tests/dialogs/prompt-dialog.test.js
+++ b/packages/botfuel-dialog/tests/dialogs/prompt-dialog.test.js
@@ -917,7 +917,7 @@ describe('PromptDialog', () => {
 
       await prompt.brain.addUser(userId);
       await prompt.execute({ user: userId }, messageEntities);
-      const conversation = await prompt.brain.getLastConversation(userId);
+      const conversation = await prompt.brain.lastConversation(userId);
       expect(conversation).toHaveProperty('testdialog');
       expect(conversation.testdialog).toHaveProperty('_entities');
       expect(conversation.testdialog).toHaveProperty('_question');

--- a/packages/botfuel-dialog/tests/dialogs/prompt-dialog.test.js
+++ b/packages/botfuel-dialog/tests/dialogs/prompt-dialog.test.js
@@ -917,7 +917,7 @@ describe('PromptDialog', () => {
 
       await prompt.brain.addUser(userId);
       await prompt.execute({ user: userId }, messageEntities);
-      const conversation = await prompt.brain.lastConversation(userId);
+      const conversation = await prompt.brain.fetchLastConversation(userId);
       expect(conversation).toHaveProperty('testdialog');
       expect(conversation.testdialog).toHaveProperty('_entities');
       expect(conversation.testdialog).toHaveProperty('_question');

--- a/packages/test-complexdialogs/tests/disgressions.test.js
+++ b/packages/test-complexdialogs/tests/disgressions.test.js
@@ -48,7 +48,7 @@ describe('Disgressions', () => {
         );
         const user = await bot.brain.getUser(userId);
         const dialogs = await bot.brain.getDialogs(userId);
-        const lastConversation = await bot.brain.getLastConversation(userId);
+        const lastConversation = await bot.brain.lastConversation(userId);
         expect(user._conversations.length).toBe(1);
         expect(dialogs.stack).toHaveLength(0);
         expect(lastConversation).toHaveProperty('travel');
@@ -95,7 +95,7 @@ describe('Disgressions', () => {
         );
         const user = await bot.brain.getUser(bot.adapter.userId);
         const dialogs = await bot.brain.getDialogs(userId);
-        const lastConversation = await bot.brain.getLastConversation(bot.adapter.userId);
+        const lastConversation = await bot.brain.lastConversation(bot.adapter.userId);
         expect(user._conversations.length).toBe(1);
         expect(dialogs.stack).toHaveLength(0);
         expect(lastConversation).toHaveProperty('travel');

--- a/packages/test-complexdialogs/tests/disgressions.test.js
+++ b/packages/test-complexdialogs/tests/disgressions.test.js
@@ -48,7 +48,7 @@ describe('Disgressions', () => {
         );
         const user = await bot.brain.getUser(userId);
         const dialogs = await bot.brain.getDialogs(userId);
-        const lastConversation = await bot.brain.lastConversation(userId);
+        const lastConversation = await bot.brain.fetchLastConversation(userId);
         expect(user._conversations.length).toBe(1);
         expect(dialogs.stack).toHaveLength(0);
         expect(lastConversation).toHaveProperty('travel');
@@ -95,7 +95,7 @@ describe('Disgressions', () => {
         );
         const user = await bot.brain.getUser(bot.adapter.userId);
         const dialogs = await bot.brain.getDialogs(userId);
-        const lastConversation = await bot.brain.lastConversation(bot.adapter.userId);
+        const lastConversation = await bot.brain.fetchLastConversation(bot.adapter.userId);
         expect(user._conversations.length).toBe(1);
         expect(dialogs.stack).toHaveLength(0);
         expect(lastConversation).toHaveProperty('travel');

--- a/packages/test-complexdialogs/tests/name.test.js
+++ b/packages/test-complexdialogs/tests/name.test.js
@@ -31,7 +31,7 @@ describe('NameDialog', () => {
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
-    const lastConversation = await bot.brain.lastConversation(userId);
+    const lastConversation = await bot.brain.fetchLastConversation(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).toHaveLength(0);
     expect(lastConversation).toHaveProperty('name');
@@ -56,7 +56,7 @@ describe('NameDialog', () => {
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
-    const lastConversation = await bot.brain.lastConversation(userId);
+    const lastConversation = await bot.brain.fetchLastConversation(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).toHaveLength(0);
     expect(lastConversation).toHaveProperty('name');

--- a/packages/test-complexdialogs/tests/name.test.js
+++ b/packages/test-complexdialogs/tests/name.test.js
@@ -31,7 +31,7 @@ describe('NameDialog', () => {
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
-    const lastConversation = await bot.brain.getLastConversation(userId);
+    const lastConversation = await bot.brain.lastConversation(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).toHaveLength(0);
     expect(lastConversation).toHaveProperty('name');
@@ -56,7 +56,7 @@ describe('NameDialog', () => {
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
-    const lastConversation = await bot.brain.getLastConversation(userId);
+    const lastConversation = await bot.brain.lastConversation(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).toHaveLength(0);
     expect(lastConversation).toHaveProperty('name');

--- a/packages/test-complexdialogs/tests/travel.test.js
+++ b/packages/test-complexdialogs/tests/travel.test.js
@@ -35,7 +35,7 @@ describe('TravelDialog', () => {
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
-    const lastConversation = await bot.brain.lastConversation(userId);
+    const lastConversation = await bot.brain.fetchLastConversation(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack.length).toBe(1);
     expect(lastConversation).toHaveProperty('travel');
@@ -60,7 +60,7 @@ describe('TravelDialog', () => {
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
-    const lastConversation = await bot.brain.lastConversation(userId);
+    const lastConversation = await bot.brain.fetchLastConversation(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).toHaveLength(0);
     expect(lastConversation).toHaveProperty('travel');
@@ -95,7 +95,7 @@ describe('TravelDialog', () => {
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
-    const lastConversation = await bot.brain.lastConversation(userId);
+    const lastConversation = await bot.brain.fetchLastConversation(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).toHaveLength(0);
     expect(lastConversation).toHaveProperty('travel');
@@ -129,7 +129,7 @@ describe('TravelDialog', () => {
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
-    const lastConversation = await bot.brain.lastConversation(userId);
+    const lastConversation = await bot.brain.fetchLastConversation(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).toHaveLength(0);
     expect(lastConversation).toHaveProperty('travel');

--- a/packages/test-complexdialogs/tests/travel.test.js
+++ b/packages/test-complexdialogs/tests/travel.test.js
@@ -35,7 +35,7 @@ describe('TravelDialog', () => {
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
-    const lastConversation = await bot.brain.getLastConversation(userId);
+    const lastConversation = await bot.brain.lastConversation(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack.length).toBe(1);
     expect(lastConversation).toHaveProperty('travel');
@@ -60,7 +60,7 @@ describe('TravelDialog', () => {
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
-    const lastConversation = await bot.brain.getLastConversation(userId);
+    const lastConversation = await bot.brain.lastConversation(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).toHaveLength(0);
     expect(lastConversation).toHaveProperty('travel');
@@ -95,7 +95,7 @@ describe('TravelDialog', () => {
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
-    const lastConversation = await bot.brain.getLastConversation(userId);
+    const lastConversation = await bot.brain.lastConversation(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).toHaveLength(0);
     expect(lastConversation).toHaveProperty('travel');
@@ -129,7 +129,7 @@ describe('TravelDialog', () => {
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
-    const lastConversation = await bot.brain.getLastConversation(userId);
+    const lastConversation = await bot.brain.lastConversation(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).toHaveLength(0);
     expect(lastConversation).toHaveProperty('travel');

--- a/packages/test-complexentities/tests/cities.test.js
+++ b/packages/test-complexentities/tests/cities.test.js
@@ -47,7 +47,7 @@ describe('CitiesDialog', () => {
     const dialogs = await bot.brain.getDialogs(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).toHaveLength(0);
-    const lastConversation = await bot.brain.lastConversation(userId);
+    const lastConversation = await bot.brain.fetchLastConversation(userId);
     expect(lastConversation).toHaveProperty('cities');
     expect(lastConversation.cities._entities).toHaveProperty('favoriteCities');
     expect(lastConversation.cities._entities.favoriteCities).toHaveLength(5);
@@ -86,7 +86,7 @@ describe('CitiesDialog', () => {
     const dialogs = await bot.brain.getDialogs(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).not.toHaveLength(0);
-    const lastConversation = await bot.brain.lastConversation(userId);
+    const lastConversation = await bot.brain.fetchLastConversation(userId);
     expect(lastConversation).toHaveProperty('cities');
     expect(lastConversation.cities._entities).toHaveProperty('favoriteCities');
     expect(lastConversation.cities._entities.favoriteCities).toHaveLength(2);

--- a/packages/test-complexentities/tests/cities.test.js
+++ b/packages/test-complexentities/tests/cities.test.js
@@ -47,7 +47,7 @@ describe('CitiesDialog', () => {
     const dialogs = await bot.brain.getDialogs(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).toHaveLength(0);
-    const lastConversation = await bot.brain.getLastConversation(userId);
+    const lastConversation = await bot.brain.lastConversation(userId);
     expect(lastConversation).toHaveProperty('cities');
     expect(lastConversation.cities._entities).toHaveProperty('favoriteCities');
     expect(lastConversation.cities._entities.favoriteCities).toHaveLength(5);
@@ -86,7 +86,7 @@ describe('CitiesDialog', () => {
     const dialogs = await bot.brain.getDialogs(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).not.toHaveLength(0);
-    const lastConversation = await bot.brain.getLastConversation(userId);
+    const lastConversation = await bot.brain.lastConversation(userId);
     expect(lastConversation).toHaveProperty('cities');
     expect(lastConversation.cities._entities).toHaveProperty('favoriteCities');
     expect(lastConversation.cities._entities.favoriteCities).toHaveLength(2);

--- a/packages/test-complexentities/tests/guess.test.js
+++ b/packages/test-complexentities/tests/guess.test.js
@@ -42,7 +42,7 @@ describe('GuessDialog', () => {
     const dialogs = await bot.brain.getDialogs(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).not.toHaveLength(0);
-    const lastConversation = await bot.brain.getLastConversation(userId);
+    const lastConversation = await bot.brain.lastConversation(userId);
     expect(lastConversation).toHaveProperty('guess');
     expect(lastConversation.guess._entities).toHaveProperty('favoriteColor');
     expect(lastConversation.guess._entities.favoriteColor.values[0]).toHaveProperty('name');

--- a/packages/test-complexentities/tests/guess.test.js
+++ b/packages/test-complexentities/tests/guess.test.js
@@ -42,7 +42,7 @@ describe('GuessDialog', () => {
     const dialogs = await bot.brain.getDialogs(userId);
     expect(user._conversations.length).toBe(1);
     expect(dialogs.stack).not.toHaveLength(0);
-    const lastConversation = await bot.brain.lastConversation(userId);
+    const lastConversation = await bot.brain.fetchLastConversation(userId);
     expect(lastConversation).toHaveProperty('guess');
     expect(lastConversation.guess._entities).toHaveProperty('favoriteColor');
     expect(lastConversation.guess._entities.favoriteColor.values[0]).toHaveProperty('name');


### PR DESCRIPTION
The problem was about the ambiguity of the 'getLastConversation' method's name since traditionally a getter method doesn't alter the state of an object.
The name was changed to 'lastConversation' and a line in the doc was added to explain what happens if the last conversation isn't valid anymore.