### PR TITLE
feat/dialog-config

### DIFF
--- a/packages/botfuel-dialog/src/config.js
+++ b/packages/botfuel-dialog/src/config.js
@@ -37,6 +37,7 @@ export type Config = {|
     spellchecking: string,
   },
   path: string,
+  custom: Object,
 |};
 
 const fs = require('fs');

--- a/packages/botfuel-dialog/src/dialogs/dialog.js
+++ b/packages/botfuel-dialog/src/dialogs/dialog.js
@@ -98,6 +98,7 @@ class Dialog {
   parameters: DialogParameters;
   viewResolver: ViewResolver;
   name: string;
+  config: Object;
 
   /*
    * @param {Object} characteristics - the characteristics of the dialog
@@ -115,6 +116,7 @@ class Dialog {
     this.parameters = parameters;
     this.viewResolver = new ViewResolver(config);
     this.name = this.getName();
+    this.config = config.custom;
   }
 
   /**


### PR DESCRIPTION
Allow `Config.custom` to be accessible in dialogs under the `Dialog.config` property