### PR TITLE
improvement/spellchecking-error-handling

### DIFF
--- a/fixtures/api.botfuel.io-443/153389863411175775
+++ b/fixtures/api.botfuel.io-443/153389863411175775
@@ -1,0 +1,16 @@
+GET /nlp/spellchecking?sentence=helllo&key=EN_1
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Fri, 10 Aug 2018 10:57:14 GMT
+content-type: application/json
+content-length: 66
+connection: close
+via: 1.1 vegur
+
+{
+  "correctSentence": "hello", 
+  "originalSentence": "helllo"
+}

--- a/fixtures/api.botfuel.io-443/153389863428175653
+++ b/fixtures/api.botfuel.io-443/153389863428175653
@@ -1,0 +1,15 @@
+GET /nlp/spellchecking?sentence=helllo&key=UNKNOWN_KEY
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 500 INTERNAL SERVER ERROR
+server: openresty/1.11.2.5
+date: Fri, 10 Aug 2018 10:57:14 GMT
+content-type: application/json
+content-length: 39
+connection: close
+via: 1.1 vegur
+
+{
+  "error": "Internal server error"
+}

--- a/packages/botfuel-dialog/src/nlus/botfuel-nlu.js
+++ b/packages/botfuel-dialog/src/nlus/botfuel-nlu.js
@@ -101,9 +101,9 @@ class BotfuelNlu extends Nlu {
   /** @inheritdoc */
   async compute(sentence, context) {
     logger.debug('compute', sentence); // Context is not loggable
+    // spellchecking (done outside the try/catch block to prevent catch-dialog to be triggered)
+    sentence = await this.spellcheck(sentence);
     try {
-      // spellchecking
-      sentence = await this.spellcheck(sentence);
       // computing entities
       const messageEntities = await this.extractor.compute(sentence);
       // computing intents
@@ -149,10 +149,19 @@ class BotfuelNlu extends Nlu {
     if (!key) {
       return sentence;
     }
-    logger.debug('spellcheck', sentence, key);
-    const result = await this.spellchecking.compute({ sentence, key });
-    logger.debug('spellcheck: result', result);
-    return result.correctSentence;
+    try {
+      logger.debug('spellcheck', sentence, key);
+      const result = await this.spellchecking.compute({ sentence, key });
+      logger.debug('spellcheck: result', result);
+      return result.correctSentence;
+    } catch (error) {
+      logger.error('spellchecking: error', error);
+      if (error.statusCode === 403) {
+        throw new AuthenticationError();
+      }
+      // in case of spellchecking error returns the original sentence
+      return sentence;
+    }
   }
 }
 

--- a/packages/botfuel-dialog/src/nlus/botfuel-nlu.js
+++ b/packages/botfuel-dialog/src/nlus/botfuel-nlu.js
@@ -101,7 +101,9 @@ class BotfuelNlu extends Nlu {
   /** @inheritdoc */
   async compute(sentence, context) {
     logger.debug('compute', sentence); // Context is not loggable
-    // spellchecking (done outside the try/catch block to prevent catch-dialog to be triggered)
+    // spellchecking
+    // this is done outside the try/catch block to prevent catch-dialog to be triggered
+    // if the error is not related to authentication
     sentence = await this.spellcheck(sentence);
     try {
       // computing entities

--- a/packages/botfuel-dialog/tests/nlus/botfuel-nlu.test.js
+++ b/packages/botfuel-dialog/tests/nlus/botfuel-nlu.test.js
@@ -69,4 +69,27 @@ describe('Botfuel Nlu', () => {
       expect(classificationResults[0].type).toEqual(ClassificationResult.TYPE_QNA);
     });
   });
+
+  describe('spellchecking', () => {
+    test('should return the original sentence when no spellchecking key', async () => {
+      const nlu = new BotfuelNlu({ nlu: {} });
+      const sentence = 'helllo';
+      const result = await nlu.spellcheck(sentence);
+      expect(result).toEqual('helllo');
+    });
+
+    test('should correct the spelling in a sentence', async () => {
+      const nlu = new BotfuelNlu({ nlu: { spellchecking: 'EN_1' } });
+      const sentence = 'helllo';
+      const result = await nlu.spellcheck(sentence);
+      expect(result).toEqual('hello');
+    });
+
+    test('should return the original sentence when error', async () => {
+      const nlu = new BotfuelNlu({ nlu: { spellchecking: 'UNKNOWN_KEY' } });
+      const sentence = 'helllo';
+      const result = await nlu.spellcheck(sentence);
+      expect(result).toEqual('helllo');
+    });
+  });
 });


### PR DESCRIPTION
Before we were triggering the `catch-dialog` in `botfuel-nlu` when the spellchecking, the entity extraction or the classification failed.

Now we are handling spellchecking error separately to be able to return the original sentence and let the bot continue is execution without triggering the `catch-dialog` if the error is not related to authentication.