### PR TITLE
Trigger default dialog when the same dialog is triggered twice without extra entity the second time

### DIFF
--- a/fixtures/api.botfuel.io-443/153683284708943108
+++ b/fixtures/api.botfuel.io-443/153683284708943108
@@ -1,0 +1,16 @@
+GET /nlp/entity-extraction/v0?sentence=I%20am%20leaving&dimensions=city&dimensions=location&timezone=CET
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Thu, 13 Sep 2018 10:00:47 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+access-control-allow-methods: GET, OPTIONS
+access-control-allow-origin: *
+access-control-allow-headers: content-type, origin, accept, Botfuel-Bot-Locale
+via: 1.1 vegur
+
+[]

--- a/fixtures/api.botfuel.io-443/153683284750164752
+++ b/fixtures/api.botfuel.io-443/153683284750164752
@@ -1,0 +1,16 @@
+GET /nlp/entity-extraction/v0?sentence=I%20am%20leaving&dimensions=color
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Thu, 13 Sep 2018 10:00:47 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+access-control-allow-methods: GET, OPTIONS
+access-control-allow-origin: *
+access-control-allow-headers: content-type, origin, accept, Botfuel-Bot-Locale
+via: 1.1 vegur
+
+[]

--- a/fixtures/api.botfuel.io-443/153683284770384882
+++ b/fixtures/api.botfuel.io-443/153683284770384882
@@ -1,0 +1,16 @@
+GET /nlp/entity-extraction/v0?sentence=I%20am%20leaving&dimensions=forename
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Thu, 13 Sep 2018 10:00:47 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+access-control-allow-methods: GET, OPTIONS
+access-control-allow-origin: *
+access-control-allow-headers: content-type, origin, accept, Botfuel-Bot-Locale
+via: 1.1 vegur
+
+[]

--- a/fixtures/api.botfuel.io-443/153683284786511736
+++ b/fixtures/api.botfuel.io-443/153683284786511736
@@ -1,0 +1,16 @@
+GET /nlp/entity-extraction/v0?sentence=I%20am%20leaving&dimensions=number
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Thu, 13 Sep 2018 10:00:47 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+access-control-allow-methods: GET, OPTIONS
+access-control-allow-origin: *
+access-control-allow-headers: content-type, origin, accept, Botfuel-Bot-Locale
+via: 1.1 vegur
+
+[]

--- a/fixtures/api.botfuel.io-443/153683284804994737
+++ b/fixtures/api.botfuel.io-443/153683284804994737
@@ -1,0 +1,16 @@
+GET /nlp/entity-extraction/v0?sentence=I%20am%20leaving&dimensions=time&timezone=CET
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Thu, 13 Sep 2018 10:00:48 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+access-control-allow-methods: GET, OPTIONS
+access-control-allow-origin: *
+access-control-allow-headers: content-type, origin, accept, Botfuel-Bot-Locale
+via: 1.1 vegur
+
+[]

--- a/fixtures/api.botfuel.io-443/153683284831572152
+++ b/fixtures/api.botfuel.io-443/153683284831572152
@@ -1,0 +1,14 @@
+GET /trainer/api/v0/classify?sentence=I%20am%20leaving
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Thu, 13 Sep 2018 10:00:48 GMT
+content-type: application/json
+content-length: 128
+connection: close
+access-control-allow-origin: *
+via: 1.1 vegur
+
+[{"id":"5b0485abfb647c001113a5ca","label":"travel","probability":0.7122221415882003,"resolvePrompt":"travel?","type":"Intent"}]

--- a/fixtures/api.botfuel.io-443/153691324381679185
+++ b/fixtures/api.botfuel.io-443/153691324381679185
@@ -1,0 +1,16 @@
+GET /nlp/entity-extraction/v0?sentence=I%20leave%20from%20Berlin%2C%20tomorrow&dimensions=city&dimensions=location&timezone=CET
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Fri, 14 Sep 2018 08:20:43 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+access-control-allow-methods: GET, OPTIONS
+access-control-allow-origin: *
+access-control-allow-headers: content-type, origin, accept, Botfuel-Bot-Locale
+via: 1.1 vegur
+
+[{"dim":"city","body":"from Berlin","values":[{"value":"Berlin","type":"string","direction":"origin"}],"start":8,"end":19}]

--- a/fixtures/api.botfuel.io-443/153691324429584252
+++ b/fixtures/api.botfuel.io-443/153691324429584252
@@ -1,0 +1,16 @@
+GET /nlp/entity-extraction/v0?sentence=I%20leave%20from%20Berlin%2C%20tomorrow&dimensions=color
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Fri, 14 Sep 2018 08:20:44 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+access-control-allow-methods: GET, OPTIONS
+access-control-allow-origin: *
+access-control-allow-headers: content-type, origin, accept, Botfuel-Bot-Locale
+via: 1.1 vegur
+
+[]

--- a/fixtures/api.botfuel.io-443/153691324466980541
+++ b/fixtures/api.botfuel.io-443/153691324466980541
@@ -1,0 +1,16 @@
+GET /nlp/entity-extraction/v0?sentence=I%20leave%20from%20Berlin%2C%20tomorrow&dimensions=forename
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Fri, 14 Sep 2018 08:20:44 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+access-control-allow-methods: GET, OPTIONS
+access-control-allow-origin: *
+access-control-allow-headers: content-type, origin, accept, Botfuel-Bot-Locale
+via: 1.1 vegur
+
+[]

--- a/fixtures/api.botfuel.io-443/153691324503565521
+++ b/fixtures/api.botfuel.io-443/153691324503565521
@@ -1,0 +1,16 @@
+GET /nlp/entity-extraction/v0?sentence=I%20leave%20from%20Berlin%2C%20tomorrow&dimensions=number
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Fri, 14 Sep 2018 08:20:45 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+access-control-allow-methods: GET, OPTIONS
+access-control-allow-origin: *
+access-control-allow-headers: content-type, origin, accept, Botfuel-Bot-Locale
+via: 1.1 vegur
+
+[]

--- a/fixtures/api.botfuel.io-443/153691324566963658
+++ b/fixtures/api.botfuel.io-443/153691324566963658
@@ -1,0 +1,16 @@
+GET /nlp/entity-extraction/v0?sentence=I%20leave%20from%20Berlin%2C%20tomorrow&dimensions=time&timezone=CET
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Fri, 14 Sep 2018 08:20:45 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+access-control-allow-methods: GET, OPTIONS
+access-control-allow-origin: *
+access-control-allow-headers: content-type, origin, accept, Botfuel-Bot-Locale
+via: 1.1 vegur
+
+[{"dim":"time","body":"tomorrow","values":[{"type":"timestamp","time-stamp":"2018-09-15T00:00:00.000+02:00","unit":"day","milliseconds":1536962400000}],"start":21,"end":29}]

--- a/fixtures/api.botfuel.io-443/15369132462794822
+++ b/fixtures/api.botfuel.io-443/15369132462794822
@@ -1,0 +1,14 @@
+GET /trainer/api/v0/classify?sentence=I%20leave%20from%20Berlin%2C%20tomorrow
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Fri, 14 Sep 2018 08:20:46 GMT
+content-type: application/json
+content-length: 128
+connection: close
+access-control-allow-origin: *
+via: 1.1 vegur
+
+[{"id":"5b0485abfb647c001113a5ca","label":"travel","probability":0.7382432933199261,"resolvePrompt":"travel?","type":"Intent"}]

--- a/packages/botfuel-dialog/src/dialog-manager.js
+++ b/packages/botfuel-dialog/src/dialog-manager.js
@@ -75,6 +75,10 @@ class DialogManager extends Resolver<Dialog> {
     );
   }
 
+  getLastDialog(dialogs: DialogsData): ?DialogData {
+    return dialogs.stack.length > 0 ? dialogs.stack[dialogs.stack.length - 1] : null;
+  }
+
   /**
    * Returns the dialogs data (stack and previous dialogs).
    */
@@ -108,12 +112,10 @@ class DialogManager extends Resolver<Dialog> {
         data: { classificationResults, messageEntities },
       };
     } else if (classificationResults.length === 1) {
-      const newDialogName = classificationResults[0].name;
-      const lastDialog: ?DialogData = dialogs.stack.length > 0
-        ? dialogs.stack[dialogs.stack.length - 1]
-        : null;
-
-      if (lastDialog && lastDialog.name === newDialogName && messageEntities.length === 0) {
+      const lastDialog: ?DialogData = this.getLastDialog(dialogs);
+      // check if last dialog is the same as the classification result and if there is no message entities
+      if (lastDialog && lastDialog.name === classificationResults[0].name && messageEntities.length === 0) {
+        // update the stack without re-assign a new object to keep the reference
         dialogs.stack = dialogs.stack.filter(d => d.name !== lastDialog.name);
         dialogs.previous = [...dialogs.previous, { ...lastDialog, date: Date.now() }];
         newDialog = {
@@ -181,7 +183,6 @@ class DialogManager extends Resolver<Dialog> {
       dialogs.stack.push(newDialog);
     }
     logger.debug('updateWithDialog: updated', dialogs);
-    logger.info('updateWithDialog: updated', dialogs);
   }
 
   /**

--- a/packages/botfuel-dialog/src/dialog-manager.js
+++ b/packages/botfuel-dialog/src/dialog-manager.js
@@ -113,8 +113,11 @@ class DialogManager extends Resolver<Dialog> {
       };
     } else if (classificationResults.length === 1) {
       const lastDialog: ?DialogData = this.getLastDialog(dialogs);
-      // check if last dialog is the same as the classification result and if there is no message entities
-      if (lastDialog && lastDialog.name === classificationResults[0].name && messageEntities.length === 0) {
+      if (
+        lastDialog &&
+        lastDialog.name === classificationResults[0].name &&
+        messageEntities.length === 0
+      ) {
         // update the stack without re-assign a new object to keep the reference
         dialogs.stack = dialogs.stack.filter(d => d.name !== lastDialog.name);
         dialogs.previous = [...dialogs.previous, { ...lastDialog, date: Date.now() }];

--- a/packages/test-complexdialogs/tests/travel.test.js
+++ b/packages/test-complexdialogs/tests/travel.test.js
@@ -139,4 +139,34 @@ describe('TravelDialog', () => {
     expect(lastConversation.travel._entities.city.values[0].value).toBe('Paris');
     expect(lastConversation.travel._entities.time.body).toBe('the day after tomorrow');
   });
+
+  test('should trigger default dialog when same dialog is triggered twice without entities', async () => {
+    const bot = new Bot(config);
+    const { adapter } = bot;
+    const { userId } = adapter;
+    await bot.play([
+      new UserTextMessage('I leave from Paris'),
+      new UserTextMessage('I am leaving'),
+    ]);
+    expect(bot.adapter.log).toEqual(
+      [
+        new UserTextMessage('I leave from Paris'),
+        new BotTextMessage('Entities defined: city'),
+        new BotTextMessage('Entities needed: time'),
+        new BotTextMessage('Which time?'),
+        new UserTextMessage('I am leaving'),
+        new BotTextMessage('Not understood.'),
+      ].map(msg => msg.toJson(userId)),
+    );
+    const user = await bot.brain.getUser(userId);
+    const dialogs = await bot.brain.getDialogs(userId);
+    const lastConversation = await bot.brain.fetchLastConversation(userId);
+    expect(user._conversations.length).toBe(1);
+    expect(dialogs.stack).toHaveLength(1);
+    expect(dialogs.previous).toHaveLength(1);
+    expect(lastConversation).toHaveProperty('travel');
+    expect(lastConversation.travel._entities).toHaveProperty('city');
+    expect(lastConversation.travel._entities.city).toHaveProperty('body');
+    expect(lastConversation.travel._entities.city.values[0].value).toBe('Paris');
+  });
 });

--- a/packages/test-complexdialogs/tests/travel.test.js
+++ b/packages/test-complexdialogs/tests/travel.test.js
@@ -164,4 +164,32 @@ describe('TravelDialog', () => {
     expect(dialogs.stack).toHaveLength(0);
     expect(dialogs.previous).toHaveLength(2);
   });
+
+  test('should trigger default dialog when same dialog is triggered twice without entities', async () => {
+    const bot = new Bot(config);
+    const { adapter } = bot;
+    const { userId } = adapter;
+    await bot.play([
+      new UserTextMessage('I leave from Paris'),
+      new UserTextMessage('I am leaving'),
+      new UserTextMessage('I leave from Berlin, tomorrow'),
+    ]);
+    expect(bot.adapter.log).toEqual(
+      [
+        new UserTextMessage('I leave from Paris'),
+        new BotTextMessage('Entities defined: city'),
+        new BotTextMessage('Entities needed: time'),
+        new BotTextMessage('Which time?'),
+        new UserTextMessage('I am leaving'),
+        new BotTextMessage('Not understood.'),
+        new UserTextMessage('I leave from Berlin, tomorrow'),
+        new BotTextMessage('Entities defined: city, time'),
+      ].map(msg => msg.toJson(userId)),
+    );
+    const user = await bot.brain.getUser(userId);
+    const dialogs = await bot.brain.getDialogs(userId);
+    expect(user._conversations.length).toBe(1);
+    expect(dialogs.stack).toHaveLength(0);
+    expect(dialogs.previous).toHaveLength(3);
+  });
 });

--- a/packages/test-complexdialogs/tests/travel.test.js
+++ b/packages/test-complexdialogs/tests/travel.test.js
@@ -156,40 +156,15 @@ describe('TravelDialog', () => {
         new BotTextMessage('Which time?'),
         new UserTextMessage('I am leaving'),
         new BotTextMessage('Not understood.'),
-      ].map(msg => msg.toJson(userId)),
-    );
-    const user = await bot.brain.getUser(userId);
-    const dialogs = await bot.brain.getDialogs(userId);
-    expect(user._conversations.length).toBe(1);
-    expect(dialogs.stack).toHaveLength(0);
-    expect(dialogs.previous).toHaveLength(2);
-  });
-
-  test('should trigger default dialog when same dialog is triggered twice without entities', async () => {
-    const bot = new Bot(config);
-    const { adapter } = bot;
-    const { userId } = adapter;
-    await bot.play([
-      new UserTextMessage('I leave from Paris'),
-      new UserTextMessage('I am leaving'),
-      new UserTextMessage('I leave from Berlin, tomorrow'),
-    ]);
-    expect(bot.adapter.log).toEqual(
-      [
-        new UserTextMessage('I leave from Paris'),
         new BotTextMessage('Entities defined: city'),
         new BotTextMessage('Entities needed: time'),
         new BotTextMessage('Which time?'),
-        new UserTextMessage('I am leaving'),
-        new BotTextMessage('Not understood.'),
-        new UserTextMessage('I leave from Berlin, tomorrow'),
-        new BotTextMessage('Entities defined: city, time'),
       ].map(msg => msg.toJson(userId)),
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
     expect(user._conversations.length).toBe(1);
-    expect(dialogs.stack).toHaveLength(0);
-    expect(dialogs.previous).toHaveLength(3);
+    expect(dialogs.stack).toHaveLength(1);
+    expect(dialogs.previous).toHaveLength(1);
   });
 });

--- a/packages/test-complexdialogs/tests/travel.test.js
+++ b/packages/test-complexdialogs/tests/travel.test.js
@@ -160,13 +160,8 @@ describe('TravelDialog', () => {
     );
     const user = await bot.brain.getUser(userId);
     const dialogs = await bot.brain.getDialogs(userId);
-    const lastConversation = await bot.brain.fetchLastConversation(userId);
     expect(user._conversations.length).toBe(1);
-    expect(dialogs.stack).toHaveLength(1);
-    expect(dialogs.previous).toHaveLength(1);
-    expect(lastConversation).toHaveProperty('travel');
-    expect(lastConversation.travel._entities).toHaveProperty('city');
-    expect(lastConversation.travel._entities.city).toHaveProperty('body');
-    expect(lastConversation.travel._entities.city.values[0].value).toBe('Paris');
+    expect(dialogs.stack).toHaveLength(0);
+    expect(dialogs.previous).toHaveLength(2);
   });
 });


### PR DESCRIPTION
With this PR the bot will trigger the **default-dialog** when the user trigger the same intent twice without new entities extracted the second time

Let's see an example with an intent **Travel** with two entity: a **date** and a **city**.
```
U: I want to travel tomorrow
B: Where ?
U: I want to travel // here the user trigger the same intent, without any entity
B: Not understood. // the bot don't ask for the city entity another time
U: Where ?
```

Related issue https://github.com/Botfuel/botfuel-dialog/issues/237