### PR TITLE
Add triggeredBy property to dialogs

### DIFF
--- a/fixtures/api.botfuel.io-443/153719099235662863
+++ b/fixtures/api.botfuel.io-443/153719099235662863
@@ -1,0 +1,16 @@
+GET /nlp/spellchecking/v1?sentence=Show%20me%20the%20products.
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Mon, 17 Sep 2018 13:29:52 GMT
+content-type: application/json
+content-length: 97
+connection: close
+via: 1.1 vegur
+
+{
+  "correctSentence": "Show me the products.", 
+  "originalSentence": "Show me the products."
+}

--- a/fixtures/api.botfuel.io-443/153719099305590782
+++ b/fixtures/api.botfuel.io-443/153719099305590782
@@ -1,0 +1,16 @@
+GET /nlp/spellchecking/v1?sentence=Show%20me%20the%20top%20hat.
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Mon, 17 Sep 2018 13:29:53 GMT
+content-type: application/json
+content-length: 95
+connection: close
+via: 1.1 vegur
+
+{
+  "correctSentence": "Show me the top hat.", 
+  "originalSentence": "Show me the top hat."
+}

--- a/fixtures/api.botfuel.io-443/153719099363180620
+++ b/fixtures/api.botfuel.io-443/153719099363180620
@@ -1,0 +1,16 @@
+GET /nlp/spellchecking/v1?sentence=Show%20me%20the%20cowboy%20hat.
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Mon, 17 Sep 2018 13:29:53 GMT
+content-type: application/json
+content-length: 101
+connection: close
+via: 1.1 vegur
+
+{
+  "correctSentence": "Show me the cowboy hat.", 
+  "originalSentence": "Show me the cowboy hat."
+}

--- a/fixtures/api.botfuel.io-443/153719099382623583
+++ b/fixtures/api.botfuel.io-443/153719099382623583
@@ -1,0 +1,16 @@
+GET /nlp/spellchecking/v1?sentence=Show%20me%20the%20detective%20hat.
+host: api.botfuel.io
+accept: application/json
+
+HTTP/1.1 200 OK
+server: openresty/1.11.2.5
+date: Mon, 17 Sep 2018 13:29:53 GMT
+content-type: application/json
+content-length: 107
+connection: close
+via: 1.1 vegur
+
+{
+  "correctSentence": "Show me the detective hat.", 
+  "originalSentence": "Show me the detective hat."
+}

--- a/packages/botfuel-dialog/src/bot.js
+++ b/packages/botfuel-dialog/src/bot.js
@@ -238,7 +238,7 @@ class Bot {
    * @private
    */
   async respondWhenFile(userMessage: FileMessage): Promise<BotMessageJson[]> {
-    logger.debug('respondWhenFile', userMessage) ;
+    logger.debug('respondWhenFile', userMessage);
     const dialog: DialogData = {
       name: 'file',
       data: {

--- a/packages/botfuel-dialog/src/bot.js
+++ b/packages/botfuel-dialog/src/bot.js
@@ -180,6 +180,7 @@ class Bot {
       const complexInputDialog: DialogData = {
         name: 'complex-input',
         data: {},
+        triggeredBy: 'dialog-manager',
       };
 
       return this.dm.executeDialog(userMessage, complexInputDialog);
@@ -211,6 +212,7 @@ class Bot {
       data: {
         messageEntities: userMessage.payload.value.data.messageEntities,
       },
+      triggeredBy: 'postback',
     };
     return this.dm.executeDialog(userMessage, dialog);
   }
@@ -226,6 +228,7 @@ class Bot {
       data: {
         url: userMessage.payload.value,
       },
+      triggeredBy: 'dialog-manager',
     };
     return this.dm.executeDialog(userMessage, dialog);
   }
@@ -235,12 +238,13 @@ class Bot {
    * @private
    */
   async respondWhenFile(userMessage: FileMessage): Promise<BotMessageJson[]> {
-    logger.debug('respondWhenFile', userMessage);
+    logger.debug('respondWhenFile', userMessage) ;
     const dialog: DialogData = {
       name: 'file',
       data: {
         url: userMessage.payload.value,
       },
+      triggeredBy: 'dialog-manager',
     };
     return this.dm.executeDialog(userMessage, dialog);
   }
@@ -276,6 +280,7 @@ class Bot {
       data: {
         error: errorObject,
       },
+      triggeredBy: 'dialog-manager',
     };
 
     return this.dm.executeDialog(userMessage, catchDialog);

--- a/packages/botfuel-dialog/src/dialog-manager.js
+++ b/packages/botfuel-dialog/src/dialog-manager.js
@@ -106,7 +106,7 @@ class DialogManager extends Resolver<Dialog> {
       newDialog = {
         name: 'classification-disambiguation',
         data: { classificationResults, messageEntities },
-        triggeredBy: 'nlu',
+        triggeredBy: 'dialog-manager',
       };
     } else if (classificationResults.length === 1) {
       newDialog = {

--- a/packages/botfuel-dialog/src/dialog-manager.js
+++ b/packages/botfuel-dialog/src/dialog-manager.js
@@ -106,6 +106,7 @@ class DialogManager extends Resolver<Dialog> {
       newDialog = {
         name: 'classification-disambiguation',
         data: { classificationResults, messageEntities },
+        triggeredBy: 'nlu',
       };
     } else if (classificationResults.length === 1) {
       newDialog = {
@@ -113,6 +114,7 @@ class DialogManager extends Resolver<Dialog> {
         data: classificationResults[0].isQnA()
           ? { answers: classificationResults[0].answers } // TODO refactor (law of Demeter)
           : { messageEntities },
+        triggeredBy: 'nlu',
       };
     }
 
@@ -131,6 +133,7 @@ class DialogManager extends Resolver<Dialog> {
             reentrant: false,
           },
           data: {},
+          triggeredBy: 'dialog-manager',
         };
         dialogs.stack.push(lastDialog);
       }
@@ -143,6 +146,7 @@ class DialogManager extends Resolver<Dialog> {
         characteristics: {
           reentrant: false,
         },
+        triggeredBy: 'dialog-manager',
       };
       dialogs.stack.push({
         ...lastDialog,
@@ -253,6 +257,7 @@ class DialogManager extends Resolver<Dialog> {
           reentrant: false,
         },
         data: {},
+        triggeredBy: 'dialog-manager',
       });
     } else {
       const dialogInstance: Dialog = this.resolve(dialog.name);

--- a/packages/botfuel-dialog/src/dialogs/dialog.js
+++ b/packages/botfuel-dialog/src/dialogs/dialog.js
@@ -168,6 +168,7 @@ class Dialog {
       newDialog: {
         name,
         data,
+        triggeredBy: `${this.getName()}-dialog`,
       },
       name: Dialog.ACTION_NEXT,
     };
@@ -186,6 +187,7 @@ class Dialog {
         newDialog: {
           name,
           data: {},
+          triggeredBy: `${this.getName()}-dialog`,
         },
       };
     }
@@ -209,6 +211,7 @@ class Dialog {
         newDialog: {
           name,
           data,
+          triggeredBy: `${this.getName()}-dialog`,
         },
       };
     }

--- a/packages/botfuel-dialog/src/types.js
+++ b/packages/botfuel-dialog/src/types.js
@@ -25,6 +25,7 @@ export type DialogDataData = {
 export type DialogData = {
   name: string,
   data: DialogDataData,
+  triggeredBy?: string,
   characteristics?: {
     reentrant: boolean,
   },

--- a/packages/botfuel-dialog/tests/dialogs/dialog.test.js
+++ b/packages/botfuel-dialog/tests/dialogs/dialog.test.js
@@ -26,10 +26,12 @@ const TEST_CONFIG = require('../../src/config').getConfiguration({
   },
 });
 
+class CustomTestDialog extends Dialog {}
+
 describe('Dialog', () => {
   const bot = new Bot(TEST_CONFIG);
-  const dialog = new Dialog(bot, {
-    namespace: 'testdialog',
+  const dialog = new CustomTestDialog(bot, {
+    namespace: 'custom-test',
     entities: {},
   });
 
@@ -51,6 +53,7 @@ describe('Dialog', () => {
       newDialog: {
         name: 'greetings',
         data: {},
+        triggeredBy: 'custom-test-dialog',
       },
       name: Dialog.ACTION_NEXT,
     });
@@ -67,6 +70,7 @@ describe('Dialog', () => {
       newDialog: {
         name: 'greetings',
         data: {},
+        triggeredBy: 'custom-test-dialog',
       },
       name: Dialog.ACTION_CANCEL,
     });
@@ -83,6 +87,7 @@ describe('Dialog', () => {
       newDialog: {
         name: 'greetings',
         data: {},
+        triggeredBy: 'custom-test-dialog',
       },
       name: Dialog.ACTION_NEW_CONVERSATION,
     });

--- a/packages/botfuel-dialog/tests/views/qnas-view.test.js
+++ b/packages/botfuel-dialog/tests/views/qnas-view.test.js
@@ -81,6 +81,8 @@ describe('QnasView', () => {
         [new PostbackMessage({ name: 'qnas', data: { messageEntities: answers } }), new BotTextMessage('answer')].map(msg =>
           msg.toJson('USER_TEST')),
       );
+      const dialogs = await bot.brain.getDialogs(bot.adapter.userId);
+      expect(dialogs.previous[0].triggeredBy).toBe('postback');
     });
   });
 });

--- a/packages/test-complexdialogs/tests/alcohol.test.js
+++ b/packages/test-complexdialogs/tests/alcohol.test.js
@@ -49,6 +49,7 @@ describe('Alcohol', () => {
     expect(dialogs.stack).toHaveLength(0);
     expect(dialogs.previous.length).toBe(1);
     expect(dialogs.previous[0].name).toBe('alcohol');
+    expect(dialogs.previous[0].triggeredBy).toBe('nlu');
     expect(await bot.brain.userGet(userId, 'isAlcoholDialogCompleted')).toBe(true);
   });
 });

--- a/packages/test-complexdialogs/tests/blank.test.js
+++ b/packages/test-complexdialogs/tests/blank.test.js
@@ -35,6 +35,7 @@ describe('Blank', () => {
     expect(dialogs.stack).toHaveLength(0);
     expect(dialogs.previous.length).toBe(1);
     expect(dialogs.previous[0].name).toBe('default');
+    expect(dialogs.previous[0].triggeredBy).toBe('dialog-manager');
   });
 
   test('should handle blank input when previous dialog is not understood', async () => {

--- a/packages/test-complexdialogs/tests/chaining.test.js
+++ b/packages/test-complexdialogs/tests/chaining.test.js
@@ -39,5 +39,6 @@ describe('Chaining', () => {
     expect(dialogs.previous.length).toBe(2);
     expect(dialogs.previous[0].name).toBe('car');
     expect(dialogs.previous[1].name).toBe('thanks');
+    expect(dialogs.previous[1].triggeredBy).toBe('car-dialog');
   });
 });

--- a/packages/test-complexdialogs/tests/greetings.test.js
+++ b/packages/test-complexdialogs/tests/greetings.test.js
@@ -41,7 +41,9 @@ describe('GreetingsDialog', () => {
     expect(dialogs.stack).toHaveLength(0);
     expect(dialogs.previous.length).toBe(2);
     expect(dialogs.previous[0].name).toBe('greetings');
+    expect(dialogs.previous[0].triggeredBy).toBe('nlu');
     expect(dialogs.previous[1].name).toBe('default');
+    expect(dialogs.previous[1].triggeredBy).toBe('dialog-manager');
   });
 
   test('should say something different when greeting for the second time', async () => {

--- a/packages/test-ecommerce/tests/products.test.js
+++ b/packages/test-ecommerce/tests/products.test.js
@@ -85,5 +85,6 @@ describe('Products', () => {
     expect(dialogs.stack).toHaveLength(0);
     expect(dialogs.previous.length).toBe(1);
     expect(dialogs.previous[0].name).toBe('products');
+    expect(dialogs.previous[0].triggeredBy).toBe('nlu');
   });
 });


### PR DESCRIPTION
Added `triggeredBy` property to dialogs.

This property can be one of the following:
- **nlu**: the dialog has been triggered by the classification results
- **dialog-manager**: the dialog has been triggered by the dialog manager, this may happen when there is no classification results (default dialog triggered), when there is too much classification results (classification-disambiguation dialog triggered) or when a confirmation is required to continue a dialog (confirmation-dialog)
- **postback**: the dialog has been triggered by the click on a postback button
- **<DIALOG_NAME>-dialog**: the dialog has been triggered by another dialog (using triggerNext or cancelPrevious or startNewConversation when the next dialog name is provided)