### PR TITLE
fix: bug that prevent to extend message object when related to BotTab…

### DIFF
--- a/packages/botfuel-dialog/src/adapters/adapter.js
+++ b/packages/botfuel-dialog/src/adapters/adapter.js
@@ -99,10 +99,8 @@ class Adapter {
    */
   extendMessage<T: UserMessage | BotMessageJson>(message: T): T {
     logger.debug('extendMessage', message);
-
-    message.id = this.getMessageUUID();
-    message.timestamp = this.getMessageTimestamp();
-    return message;
+    //Extend message by copy
+    return {...message, id:this.getMessageUUID(), timestamp:this.getMessageTimestamp()};
   }
   /**
    * Generates an uuid

--- a/packages/botfuel-dialog/src/adapters/adapter.js
+++ b/packages/botfuel-dialog/src/adapters/adapter.js
@@ -99,8 +99,13 @@ class Adapter {
    */
   extendMessage<T: UserMessage | BotMessageJson>(message: T): T {
     logger.debug('extendMessage', message);
-    //Extend message by copy
-    return {...message, id:this.getMessageUUID(), timestamp:this.getMessageTimestamp()};
+
+    // $FlowFixMe
+    return {
+      ...message,
+      id: this.getMessageUUID(),
+      timestamp: this.getMessageTimestamp(),
+    };
   }
   /**
    * Generates an uuid


### PR DESCRIPTION
…leMessage and Botmeter. Now extend is made by copy.