### PR TITLE
fix/api-dns-not-found

### DIFF
--- a/packages/botfuel-dialog/src/extractors/ws-extractor.js
+++ b/packages/botfuel-dialog/src/extractors/ws-extractor.js
@@ -83,6 +83,7 @@ class WsExtractor extends Extractor {
       },
       rejectUnauthorized: false,
       json: true,
+      family: 4,
     });
   }
 

--- a/packages/botfuel-dialog/src/nlus/botfuel-nlu.js
+++ b/packages/botfuel-dialog/src/nlus/botfuel-nlu.js
@@ -130,6 +130,7 @@ class BotfuelNlu extends Nlu {
           'App-Key': process.env.BOTFUEL_APP_KEY,
         },
         json: true,
+        family: 4,
       };
       const res = await rp(options);
       let classificationResults = res.map(data => new ClassificationResult(data));
@@ -178,8 +179,9 @@ class BotfuelNlu extends Nlu {
           'App-Key': process.env.BOTFUEL_APP_KEY,
           'Botfuel-Bot-Id': process.env.BOTFUEL_APP_TOKEN,
         },
+        family: 4,
       };
-      const result = await rp({ ...options });
+      const result = await rp(options);
       logger.debug('spellcheck: result', result);
       return result.correctSentence;
     } catch (error) {


### PR DESCRIPTION
Force request-promise to look for an ipv4 address to prevent errors of type getaddrinfo ENOTFOUND