### PR TITLE
Allow custom data in Postback messages

### DIFF
--- a/packages/botfuel-dialog/src/bot.js
+++ b/packages/botfuel-dialog/src/bot.js
@@ -206,9 +206,7 @@ class Bot {
     logger.debug('respondWhenPostback', { userMessage });
     const dialog = {
       name: userMessage.payload.value.name,
-      data: {
-        messageEntities: userMessage.payload.value.data.messageEntities,
-      },
+      data: userMessage.payload.value.data,
       triggeredBy: 'postback',
     };
     return this.dm.executeDialog(userMessage, dialog);

--- a/packages/botfuel-dialog/tests/messages/postback-message.test.js
+++ b/packages/botfuel-dialog/tests/messages/postback-message.test.js
@@ -43,4 +43,41 @@ describe('PostbackMessage', () => {
       },
     });
   });
+
+  test('should generate the proper json with a custom data key', async () => {
+    const message = new PostbackMessage({ name: 'greetings', data: { messageEntities: [], foo: 'bar' } });
+    expect(message.toJson('USER')).toEqual({
+      type: 'postback',
+      sender: 'user',
+      user: 'USER',
+      payload: {
+        value: {
+          name: 'greetings',
+          data: {
+            messageEntities: [],
+            foo: 'bar',
+          },
+        },
+      },
+    });
+  });
+
+  test('should generate the proper json with many custom data keys', async () => {
+    const message = new PostbackMessage({ name: 'greetings', data: { messageEntities: [], foo: 'bar', custom: 'key' } });
+    expect(message.toJson('USER')).toEqual({
+      type: 'postback',
+      sender: 'user',
+      user: 'USER',
+      payload: {
+        value: {
+          name: 'greetings',
+          data: {
+            messageEntities: [],
+            foo: 'bar',
+            custom: 'key',
+          },
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
Before only `messageEntities` where passed to the dialog data, now we allow custom keys.