### PR TITLE
feat: handle UserMessage with origin option in botfuel-adapter

### DIFF
--- a/packages/botfuel-dialog/src/adapters/botfuel-adapter.js
+++ b/packages/botfuel-dialog/src/adapters/botfuel-adapter.js
@@ -16,6 +16,8 @@
 
 const logger = require('logtown')('BotfuelAdapter');
 const WebAdapter = require('./web-adapter');
+const UserTextMessage = require('../messages/user-text-message');
+const PostbackMessage = require('../messages/postback-message');
 
 const CHAT_SERVER_URL = process.env.CHAT_SERVER || 'https://webchat.botfuel.io';
 
@@ -27,8 +29,15 @@ class BotfuelAdapter extends WebAdapter {
   /** @inheritDoc */
   async handleRequest(req, res) {
     logger.debug('handleRequest', req.body);
-    res.sendStatus(200);
-    await this.handleMessage(req.body);
+    let userMessage = null;
+    try {
+      userMessage = this.buildUserMessage(req.body);
+      logger.debug('handleRequest: userMessage', userMessage);
+      res.sendStatus(200);
+      return this.handleMessage(req.body);
+    } catch (error) {
+      return res.status(400).send({ message: error.message, error });
+    }
   }
 
   /** @inheritDoc */
@@ -46,6 +55,31 @@ class BotfuelAdapter extends WebAdapter {
   /** @inheritDoc */
   getBody(botMessage) {
     return botMessage;
+  }
+
+  /**
+   * Build the user message from the request body
+   * @param message {Object} - the request body
+   * @returns {BotMessageJson} - the user message in JSON format
+   */
+  buildUserMessage(message) {
+    // Define message origin property
+    const origin = {
+      platform: 'Botfuel Webchat',
+      referrer: message.referrer,
+    };
+    let userMessage = null;
+    switch(message.type) {
+      case 'postback':
+        userMessage = new PostbackMessage(message.payload.value, { origin });
+        break;
+      case 'text':
+        userMessage = new UserTextMessage(message.payload.value, { origin });
+        break;
+      default:
+        userMessage = new UserTextMessage(`Message of type ${message.type} are not supported.`);
+    }
+    return userMessage.toJson(message.user);
   }
 }
 

--- a/packages/botfuel-dialog/src/adapters/botfuel-adapter.js
+++ b/packages/botfuel-dialog/src/adapters/botfuel-adapter.js
@@ -68,8 +68,9 @@ class BotfuelAdapter extends WebAdapter {
       platform: 'Botfuel Webchat',
       referrer: message.referrer,
     };
+    // Build message
     let userMessage = null;
-    switch(message.type) {
+    switch (message.type) {
       case 'postback':
         userMessage = new PostbackMessage(message.payload.value, { origin });
         break;
@@ -79,6 +80,7 @@ class BotfuelAdapter extends WebAdapter {
       default:
         userMessage = new UserTextMessage(`Message of type ${message.type} are not supported.`);
     }
+    // Add user ID and timestamp to message then return it
     return userMessage.toJson(message.user);
   }
 }

--- a/packages/botfuel-dialog/src/adapters/botfuel-adapter.js
+++ b/packages/botfuel-dialog/src/adapters/botfuel-adapter.js
@@ -34,7 +34,7 @@ class BotfuelAdapter extends WebAdapter {
       userMessage = this.buildUserMessage(req.body);
       logger.debug('handleRequest: userMessage', userMessage);
       res.sendStatus(200);
-      return this.handleMessage(req.body);
+      return this.handleMessage(userMessage);
     } catch (error) {
       return res.status(400).send({ message: error.message, error });
     }
@@ -65,7 +65,7 @@ class BotfuelAdapter extends WebAdapter {
   buildUserMessage(message) {
     // Define message origin property
     const origin = {
-      platform: 'Botfuel Webchat',
+      adapter: 'Botfuel',
       referrer: message.referrer,
     };
     // Build message

--- a/packages/botfuel-dialog/src/adapters/botfuel-adapter.js
+++ b/packages/botfuel-dialog/src/adapters/botfuel-adapter.js
@@ -64,7 +64,7 @@ class BotfuelAdapter extends WebAdapter {
   buildUserMessage(message) {
     // Define message origin property
     const origin = {
-      adapter: 'Botfuel',
+      adapter: 'botfuel',
       referrer: message.referrer,
     };
     // Build message

--- a/packages/botfuel-dialog/src/adapters/botfuel-adapter.js
+++ b/packages/botfuel-dialog/src/adapters/botfuel-adapter.js
@@ -29,9 +29,8 @@ class BotfuelAdapter extends WebAdapter {
   /** @inheritDoc */
   async handleRequest(req, res) {
     logger.debug('handleRequest', req.body);
-    let userMessage = null;
     try {
-      userMessage = this.buildUserMessage(req.body);
+      const userMessage = this.buildUserMessage(req.body);
       logger.debug('handleRequest: userMessage', userMessage);
       res.sendStatus(200);
       return this.handleMessage(userMessage);


### PR DESCRIPTION
In the Botfuel adapter, new messages are now handled by building a `UserMessage` instead of sending the request body to the bot.

These messages have now a `options.origin` property which have the following format:

```javascript
...
payload: {
  value: <value>
  options: {
    origin: {
      platform: 'Botfuel Webchat',
      referrer: <the_referrer_url>
    }
  }
}
...
```