### PR TITLE
fix/proxy-headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,13 @@
 {
   "private": true,
   "scripts": {
-    "bootstrap":
-      "lerna bootstrap && lerna run build --scope botfuel-dialog && lerna link --force-local",
+    "bootstrap": "lerna bootstrap && lerna run build --scope botfuel-dialog && lerna link --force-local",
     "clean": "lerna clean && node clean.js",
     "type-check": "yarn flow",
     "style": "lerna run style",
     "commitmsg": "node check-commit-msg.js",
     "pretest": "yarn run bootstrap",
-    "release":
-      "yarn test && lerna run build --scope botfuel-dialog && lerna publish --conventional-commits --changelog-preset=angular",
+    "release": "yarn test && lerna run build --scope botfuel-dialog && lerna publish --conventional-commits --changelog-preset=angular",
     "unit-test": "BOTFUEL_APP_TOKEN=TEST_BOT BOTFUEL_APP_ID=TEST_BOT BOTFUEL_APP_KEY=TEST_BOT jest packages/botfuel-dialog",
     "test": "jest --forceExit"
   },

--- a/packages/botfuel-dialog/src/extractors/ws-extractor.js
+++ b/packages/botfuel-dialog/src/extractors/ws-extractor.js
@@ -80,6 +80,7 @@ class WsExtractor extends Extractor {
       headers: {
         'App-Id': process.env.BOTFUEL_APP_ID,
         'App-Key': process.env.BOTFUEL_APP_KEY,
+        'Botfuel-Bot-Id': process.env.BOTFUEL_APP_TOKEN,
       },
       rejectUnauthorized: false,
       json: true,

--- a/packages/botfuel-dialog/src/nlus/botfuel-nlu.js
+++ b/packages/botfuel-dialog/src/nlus/botfuel-nlu.js
@@ -130,13 +130,15 @@ class BotfuelNlu extends Nlu {
           userId: context.userMessage.user,
         },
         headers: {
-          'Botfuel-Bot-Id': process.env.BOTFUEL_APP_TOKEN,
           'App-Id': process.env.BOTFUEL_APP_ID,
           'App-Key': process.env.BOTFUEL_APP_KEY,
+          'Botfuel-Bot-Id': process.env.BOTFUEL_APP_TOKEN,
+          'Botfuel-Bot-Locale': this.config.locale,
         },
         json: true,
         family: 4,
       };
+      logger.info('classify: request options', options);
       const res = await measure('classify')(() => rp(options));
       let classificationResults = res.map(data => new ClassificationResult(data));
       if (this.classificationFilter) {
@@ -183,11 +185,13 @@ class BotfuelNlu extends Nlu {
           'App-Id': process.env.BOTFUEL_APP_ID,
           'App-Key': process.env.BOTFUEL_APP_KEY,
           'Botfuel-Bot-Id': process.env.BOTFUEL_APP_TOKEN,
+          'Botfuel-Bot-Locale': this.config.locale,
         },
         family: 4,
       };
       const result = await rp(options);
       logger.debug('spellcheck: result', result);
+      logger.info('spellcheck: request options', options);
       return result.correctSentence;
     } catch (error) {
       logger.error('spellchecking: error', error);


### PR DESCRIPTION
##added
- botfuel-bot-id and botfuel-bot-locale headers to api requests

> The **botfuel-bot-locale** header can't be added to `WsExtractor` because we don't expose the configuration to the extractor