### PR TITLE
perf: run compute functions in parallel into CompositeExtractor

### DIFF
--- a/packages/botfuel-dialog/src/extractors/composite-extractor.js
+++ b/packages/botfuel-dialog/src/extractors/composite-extractor.js
@@ -24,13 +24,22 @@ class CompositeExtractor extends Extractor {
   // eslint-disable-next-line require-jsdoc
   async compute(sentence) {
     logger.debug('compute', sentence);
-    let entities = [];
-    for (const extractor of this.parameters.extractors) {
-      // TODO: in parallel
-      // eslint-disable-next-line no-await-in-loop
-      const extractorEntities = await extractor.compute(sentence);
-      entities = entities.concat(extractorEntities);
+
+    // Prepare all async compute functions
+    const promises = [];
+    for (let i = 0; i < this.parameters.extractors.length; i += 1) {
+      promises.push(this.parameters.extractors[i].compute(sentence));
     }
+
+    // Execute in parallel async compute functions
+    const promisesResults = await Promise.all(promises);
+
+    // Build entities array
+    let entities = [];
+    for (let i = 0; i < promisesResults.length; i += 1) {
+      entities = entities.concat(promisesResults[i]);
+    }
+
     return entities;
   }
 }


### PR DESCRIPTION
Improve `CompositeExtractor` by executing extractors `compute()` async method in parallel.

Benchmarked with 8 corpus extractors, 4 web service extractors, 1 RegExp extractor and 1 custom extractor, the previous way took 1113.778ms. The new way took 457.293ms.