### PR TITLE
feat: Add QnAs label into ClassificationResults

### DIFF
--- a/packages/botfuel-dialog/src/dialog-manager.js
+++ b/packages/botfuel-dialog/src/dialog-manager.js
@@ -140,7 +140,7 @@ class DialogManager extends Resolver<Dialog> {
         newDialog = {
           name: classificationResults[0].name,
           data: classificationResults[0].isQnA()
-            ? { answers: classificationResults[0].answers } // TODO refactor (law of Demeter)
+            ? { answers: classificationResults[0].answers, label: classificationResults[0].label } // TODO refactor (law of Demeter)
             : { messageEntities },
           triggeredBy: 'nlu',
         };


### PR DESCRIPTION
Add QnAs label into ClassificationResults to be able to retreived it into the bot, for example into out middleware to send it to analytics tool.