### PR TITLE
feat/message-parts-options

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  babelrcRoots: ['.', './packages/*'],
+};

--- a/packages/botfuel-dialog/src/dialog-manager.js
+++ b/packages/botfuel-dialog/src/dialog-manager.js
@@ -115,7 +115,10 @@ class DialogManager extends Resolver {
         newDialog = {
           name: classificationResults[0].name,
           data: classificationResults[0].isQnA()
-            ? { answers: classificationResults[0].answers, label: classificationResults[0].label } // TODO refactor (law of Demeter)
+            ? {
+              answers: classificationResults[0].answers,
+              label: classificationResults[0].label,
+            } // TODO refactor (law of Demeter)
             : { messageEntities },
           triggeredBy: 'nlu',
         };

--- a/packages/botfuel-dialog/src/messages/action.js
+++ b/packages/botfuel-dialog/src/messages/action.js
@@ -37,12 +37,17 @@ class Action extends Part {
 
   /** @inheritDoc */
   toJson() {
-    return {
+    const actionJson = {
       type: this.type,
       text: this.text,
       value: this.value,
-      options: this.options,
     };
+
+    if (Object.keys(this.options).length > 0) {
+      actionJson.options = this.options;
+    }
+
+    return actionJson;
   }
 
   /** @inheritDoc */

--- a/packages/botfuel-dialog/src/messages/action.js
+++ b/packages/botfuel-dialog/src/messages/action.js
@@ -25,12 +25,14 @@ class Action extends Part {
    * @param {String} type - the action type
    * @param {String} text - the text
    * @param {Object|*} value - the value
+   * @param {Object} [options] - the action options
    */
-  constructor(type, text, value) {
+  constructor(type, text, value, options = {}) {
     super();
     this.type = type;
     this.text = text;
     this.value = value;
+    this.options = options;
   }
 
   /** @inheritDoc */
@@ -39,6 +41,7 @@ class Action extends Part {
       type: this.type,
       text: this.text,
       value: this.value,
+      options: this.options,
     };
   }
 

--- a/packages/botfuel-dialog/src/messages/card.js
+++ b/packages/botfuel-dialog/src/messages/card.js
@@ -52,7 +52,7 @@ class Card extends Part {
       cardJson.subtitle = this.subtitle;
     }
 
-    if (this.options) {
+    if (Object.keys(this.options).length > 0) {
       cardJson.options = this.options;
     }
 

--- a/packages/botfuel-dialog/src/messages/card.js
+++ b/packages/botfuel-dialog/src/messages/card.js
@@ -28,13 +28,15 @@ class Card extends Part {
    * @param {String} imageUrl - the image url
    * @param {Object[]} actions - an array of actions
    * @param {Object} [subtitle] - the subtitle (optional)
+   * @param {Object} [options] - the action options
    */
-  constructor(title, imageUrl, actions, subtitle = '') {
+  constructor(title, imageUrl, actions, subtitle = '', options = {}) {
     super();
     this.title = title;
     this.imageUrl = imageUrl;
-    this.subtitle = subtitle;
     this.actions = actions;
+    this.subtitle = subtitle;
+    this.options = options;
   }
 
   /** @inheritDoc */
@@ -45,9 +47,15 @@ class Card extends Part {
       image_url: this.imageUrl,
       buttons: this.actions.map(action => action.toJson()),
     };
+
     if (this.subtitle !== '') {
       cardJson.subtitle = this.subtitle;
     }
+
+    if (this.options) {
+      cardJson.options = this.options;
+    }
+
     return cardJson;
   }
 

--- a/packages/botfuel-dialog/src/messages/link.js
+++ b/packages/botfuel-dialog/src/messages/link.js
@@ -25,9 +25,10 @@ class Link extends Action {
    * @constructor
    * @param {String} title - the link title
    * @param {String} url - the link url
+   * @param {Object} [options] - the action options
    */
-  constructor(title, url) {
-    super('link', title, url);
+  constructor(title, url, options = {}) {
+    super('link', title, url, options);
   }
 
   /** @inheritDoc */

--- a/packages/botfuel-dialog/src/messages/message.js
+++ b/packages/botfuel-dialog/src/messages/message.js
@@ -25,9 +25,9 @@ class Message extends ValidObject {
    * @param type - the message type
    * @param sender - the message sender, the bot or the user
    * @param value - the message value
-   * @param options - the message options
+   * @param {Object} [options] - the message options
    */
-  constructor(type, sender, value, options) {
+  constructor(type, sender, value, options = {}) {
     super();
     this.type = type;
     this.sender = sender;
@@ -38,23 +38,28 @@ class Message extends ValidObject {
   /**
    * Converts a message to json and adds to it the bot and user ids.
    * @param userId - the user id
-   * @returns the json message
+   * @returns {Object} - the json message
    */
   toJson(userId) {
-    return {
+    const messageJson = {
       type: this.type,
       sender: this.sender,
       user: userId,
       payload: {
         value: this.valueAsJson(),
-        options: this.options,
       },
     };
+
+    if (Object.keys(this.options).length > 0) {
+      messageJson.payload.options = this.options;
+    }
+
+    return messageJson;
   }
 
   /**
    * Returns the value as json.
-   * @returns the json value
+   * @returns {*} - the json value
    */
   valueAsJson() {
     return this.value;

--- a/packages/botfuel-dialog/src/messages/postback.js
+++ b/packages/botfuel-dialog/src/messages/postback.js
@@ -25,9 +25,10 @@ class Postback extends Action {
    * @constructor
    * @param {String} text - the postback text
    * @param {Object} dialogData - the postback dialog information, like name or entities
+   * @param {Object} [options] - the action options
    */
-  constructor(text, dialogData) {
-    super('postback', text, dialogData);
+  constructor(text, dialogData, options = {}) {
+    super('postback', text, dialogData, options);
   }
 
   /** @inheritDoc */

--- a/packages/botfuel-dialog/tests/messages/action.test.js
+++ b/packages/botfuel-dialog/tests/messages/action.test.js
@@ -34,4 +34,15 @@ describe('Action', () => {
       value: 'value',
     });
   });
+
+  test('should generate the proper json with options', async () => {
+    expect(new Action('type', 'text', 'value', { className: 'my-class' }).toJson()).toEqual({
+      type: 'type',
+      text: 'text',
+      value: 'value',
+      options: {
+        className: 'my-class',
+      },
+    });
+  });
 });

--- a/packages/botfuel-dialog/tests/messages/actions-message.test.js
+++ b/packages/botfuel-dialog/tests/messages/actions-message.test.js
@@ -40,4 +40,25 @@ describe('ActionsMessage', () => {
       },
     });
   });
+
+  test('should generate the proper json with action options', async () => {
+    const message = new ActionsMessage([new Link('Botfuel', 'https://www.botfuel.io/en', { className: 'my-class' })]);
+    expect(message.toJson('USER')).toEqual({
+      type: 'actions',
+      sender: 'bot',
+      user: 'USER',
+      payload: {
+        value: [
+          {
+            type: 'link',
+            text: 'Botfuel',
+            value: 'https://www.botfuel.io/en',
+            options: {
+              className: 'my-class',
+            },
+          },
+        ],
+      },
+    });
+  });
 });

--- a/packages/botfuel-dialog/tests/messages/card.test.js
+++ b/packages/botfuel-dialog/tests/messages/card.test.js
@@ -15,6 +15,7 @@
  */
 
 const Card = require('../../src/messages/card');
+const Link = require('../../src/messages/link');
 const MessageError = require('../../src/errors/message-error');
 
 describe('Card', () => {
@@ -27,5 +28,32 @@ describe('Card', () => {
     expect(() => new Card('title', 'http://domain.com', ['not an action']).validate()).toThrow(
       MessageError,
     );
+  });
+
+  test('should generate the proper json', async () => {
+    const card = new Card(
+      'title',
+      'http://domain.com',
+      [new Link('Botfuel', 'https://www.botfuel.io/en', { className: 'link-class' })],
+      '',
+      { className: 'card-class' },
+    );
+    expect(card.toJson('USER')).toEqual({
+      title: 'title',
+      image_url: 'http://domain.com',
+      buttons: [
+        {
+          type: 'link',
+          text: 'Botfuel',
+          value: 'https://www.botfuel.io/en',
+          options: {
+            className: 'link-class',
+          },
+        },
+      ],
+      options: {
+        className: 'card-class',
+      },
+    });
   });
 });


### PR DESCRIPTION
## Added
- `options` for cards item and actions
- unit test to test new options property on actions and cards item

## Updated
- refactored options check for method `Message.toJson()` and overrides


### Note

This is the first part for supporting `className` and `style` options in the webchat